### PR TITLE
ci(github): 自動的にIssueとPRに作成者を割り当てるワークフローの追加

### DIFF
--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -1,0 +1,19 @@
+name: Assign Author
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  assign:
+    name: Assign author to Issue or PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign author
+        uses: technote-space/assign-author@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Pull Request 概要

新規に作成されたIssueおよびPRに対して、作成者を自動的に担当者として割り当てるGitHub Actionsワークフローを追加しました。

## 変更内容

- technote-space/assign-author@v1アクションを使用したワークフローを追加
- IssueとPRの作成時に自動的に作成者を担当者として割り当て

## 動作確認

1. 新しいIssueを作成し、作成者が担当者として自動的に割り当てられることを確認
2. 新しいPRを作成し、作成者が担当者として自動的に割り当てられることを確認

## 関連Issue

- なし

## レビューポイント

- ワークフローが正しく動作するかどうか
- 他のワークフローやプロジェクトに影響がないか

<!-- for GitHub Copilot review rule -->
<!--
[must]       → must fix (修正必須)
[suggestion]→ suggestion (提案)
[nit]        → nit (軽微な指摘)
[question]   → question (確認したい点)
[info]       → info (参考情報)
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->