### PR TITLE
ci(github): Issueをプロジェクトに自動的に追加・更新するワークフローを追加

### DIFF
--- a/.github/workflows/add-issue-to-project-with-status.yml
+++ b/.github/workflows/add-issue-to-project-with-status.yml
@@ -7,6 +7,9 @@ on:
       - reopened
       - labeled
 
+env:
+  PROJECT_URL: https://github.com/users/Ojoxux/projects/1
+
 jobs:
   add-issue-with-status:
     name: Add Issue to Project with Status
@@ -16,7 +19,7 @@ jobs:
         uses: actions/add-to-project@v0.5.0
         id: add-to-project
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           
       # 新機能・機能改善の場合
@@ -24,7 +27,7 @@ jobs:
         if: success() && (contains(github.event.issue.labels.*.name, 'feature') || contains(github.event.issue.labels.*.name, 'enhancement'))
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.add-to-project.outputs.itemId }}
           field-keys: Status
@@ -35,7 +38,7 @@ jobs:
         if: success() && contains(github.event.issue.labels.*.name, 'bug')
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.add-to-project.outputs.itemId }}
           field-keys: Status
@@ -46,7 +49,7 @@ jobs:
         if: success() && (contains(github.event.issue.labels.*.name, 'refactor') || contains(github.event.issue.labels.*.name, 'style') || contains(github.event.issue.labels.*.name, 'chore'))
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.add-to-project.outputs.itemId }}
           field-keys: Status
@@ -57,19 +60,23 @@ jobs:
         if: success() && (contains(github.event.issue.labels.*.name, 'documentation') || contains(github.event.issue.labels.*.name, 'ci/cd'))
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.add-to-project.outputs.itemId }}
           field-keys: Status
           field-values: "📝 やること（TODO）"
           
       # 優先度ラベルがある場合もTODOに設定（実際の作業開始は手動で変更）
-      - name: Set Status - やること（高優先度）
+      - name: Set Status - やること（優先度付き）
         if: |
-          success() && contains(github.event.issue.labels.*.name, '優先度: 高')
+          success() && (
+            contains(github.event.issue.labels.*.name, '優先度: 高') ||
+            contains(github.event.issue.labels.*.name, '優先度: 中') ||
+            contains(github.event.issue.labels.*.name, '優先度: 低')
+          )
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.add-to-project.outputs.itemId }}
           field-keys: Status
@@ -87,10 +94,12 @@ jobs:
           !contains(github.event.issue.labels.*.name, 'chore') && 
           !contains(github.event.issue.labels.*.name, 'documentation') && 
           !contains(github.event.issue.labels.*.name, 'ci/cd') && 
-          !contains(github.event.issue.labels.*.name, '優先度: 高')
+          !contains(github.event.issue.labels.*.name, '優先度: 高') &&
+          !contains(github.event.issue.labels.*.name, '優先度: 中') &&
+          !contains(github.event.issue.labels.*.name, '優先度: 低')
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.add-to-project.outputs.itemId }}
           field-keys: Status
@@ -145,13 +154,13 @@ jobs:
         if: steps.get-item.outputs.result
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.get-item.outputs.result }}
           field-keys: Status
           field-values: |
             ${{
-              contains(github.event.issue.labels.*.name, '優先度: 高') && '📝 やること（TODO）' ||
+              (contains(github.event.issue.labels.*.name, '優先度: 高') || contains(github.event.issue.labels.*.name, '優先度: 中') || contains(github.event.issue.labels.*.name, '優先度: 低')) && '📝 やること（TODO）' ||
               contains(github.event.issue.labels.*.name, 'bug') && '📝 やること（TODO）' ||
               (contains(github.event.issue.labels.*.name, 'feature') || contains(github.event.issue.labels.*.name, 'enhancement')) && '📝 やること（TODO）' ||
               (contains(github.event.issue.labels.*.name, 'refactor') || contains(github.event.issue.labels.*.name, 'style') || contains(github.event.issue.labels.*.name, 'chore')) && '📝 やること（TODO）' ||

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+env:
+  PROJECT_URL: https://github.com/users/Ojoxux/projects/1
+
 jobs:
   add-to-project:
     name: Add Issue to Project
@@ -15,8 +18,8 @@ jobs:
         id: add-to-project
         with:
           # Ojoxux/Sonoryリポジトリ用のプロジェクトURL
-          # プロジェクト番号は実際のプロジェクト番号に変更してください
-          project-url: https://github.com/users/Ojoxux/projects/1
+          # プロジェクト番号は env.PROJECT_URL で管理
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           
       # デフォルトで「💡 アイデア」ステータスを設定
@@ -24,7 +27,7 @@ jobs:
         if: success()
         uses: titoportas/update-project-fields@v0.1.0
         with:
-          project-url: https://github.com/users/Ojoxux/projects/1
+          project-url: ${{ env.PROJECT_URL }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           item-id: ${{ steps.add-to-project.outputs.itemId }}
           field-keys: Status


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Pull Request 概要

<!-- PR の目的・背景を簡潔に記載 -->

GitHubでIssueが作成されたときに、自動的にProjectsに追加し、ラベルに基づいて適切なステータスを設定するCIワークフローを追加しました。

## 変更内容

<!-- 行った変更・追加を箇条書きで記載 -->
- GitHub Actions ワークフローを2つ追加
  - `add-issue-to-project.yml`: 基本版（全てのIssueを「💡 アイデア」に設定）
  - `add-issue-to-project-with-status.yml`: スマートステータス版（ラベルに基づく自動振り分け）
- 既存ラベル体系に対応した自動ステータス設定機能
- ラベル変更時の自動ステータス更新機能

## 動作確認

<!-- 該当箇所の動作確認手順やスクリーンショットなど -->
1. マージ後に検証します

## 関連Issue

<!-- 関連する Issue 番号やリンクを記載 -->
- Closes #82 

## レビューポイント

<!-- 特に見てほしい箇所や注意点 -->
- ワークフローの構文とロジックが正しいか
- 既存ラベル（`bug`, `feature`, `enhancement`, `refactor`, `style`, `chore`, `documentation`, `ci/cd`, `優先度: 高/中/低`）との対応関係
- プロジェクトURL（`https://github.com/users/Ojoxux/projects/1`）の設定が適切か
- 自動化の範囲（アイデア・TODO段階は自動、作業中以降は手動）が実用的か

## その他
- `優先度: 高`でも「🚧 作業中」ではなく「📝 やること（TODO）」に設定（実際の作業開始は手動でコントロール）
- 2つのワークフローから用途に応じて選択可能（推奨はスマートステータス版）
- 既存のラベル体系をそのまま活用し、追加のラベル作成は不要

<!-- for GitHub Copilot review rule -->
<!--
[must]       → must fix (修正必須)
[suggestion]→ suggestion (提案)
[nit]        → nit (軽微な指摘)
[question]   → question (確認したい点)
[info]       → info (参考情報)
-->

- ワークフローの構文とロジックが正しいか
- 既存ラベル（`bug`, `feature`, `enhancement`, `refactor`, `style`, `chore`, `documentation`, `ci/cd`, `優先度: 高/中/低`）との対応関係
- プロジェクトURL（`https://github.com/users/Ojoxux/projects/1`）の設定が適切か
- 自動化の範囲（アイデア・TODO段階は自動、作業中以降は手動）が実用的か
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->