### PR TITLE
fix: AI分析結果画面での波形チカチカ問題を修正

### DIFF
--- a/apps/web/src/components/organisms/AudioPlayback/index.tsx
+++ b/apps/web/src/components/organisms/AudioPlayback/index.tsx
@@ -4,7 +4,7 @@ import { useInferenceStore } from "@/store/useInferenceStore"
 import { useRecorderStore } from "@/store/useRecorderStore"
 import { useSoundPinStore } from "@/store/useSoundPinStore"
 import { motion } from "framer-motion"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { MdClose } from "react-icons/md"
 import { SonicLoader } from "../../atoms/SonicLoader"
 import { SoundWaveBackground } from "../../atoms/SoundWaveBackground"
@@ -74,7 +74,7 @@ export function AudioPlayback({
    /**
     * 録音時間をフォーマット
     */
-   const formatRecordedAt = (date: Date): string => {
+   const formatRecordedAt = useCallback((date: Date): string => {
       return date.toLocaleString("ja-JP", {
          year: "numeric",
          month: "2-digit",
@@ -83,14 +83,28 @@ export function AudioPlayback({
          minute: "2-digit",
          second: "2-digit",
       })
-   }
+   }, [])
 
    /**
     * 信頼度をパーセンテージでフォーマット
     */
-   const formatConfidence = (confidence: number): string => {
+   const formatConfidence = useCallback((confidence: number): string => {
       return `${Math.round(confidence * 100)}%`
-   }
+   }, [])
+
+   /**
+    * 波形プレイヤーの準備完了時のコールバック（メモ化）
+    */
+   const handleWaveformReady = useCallback(() => {
+      // TODO: 音声準備完了時の処理を実装
+   }, [])
+
+   /**
+    * 波形プレイヤーの再生完了時のコールバック（メモ化）
+    */
+   const handleWaveformFinish = useCallback(() => {
+      // TODO: 音声再生完了時の処理を実装
+   }, [])
 
    /**
     * 続けるボタンのクリックハンドラー
@@ -324,12 +338,8 @@ export function AudioPlayback({
                            waveColor="#9ca3af"
                            progressColor="#dc2626"
                            className="w-full"
-                           onReady={() => {
-                              // TODO: 音声準備完了時の処理を実装
-                           }}
-                           onFinish={() => {
-                              // TODO: 音声再生完了時の処理を実装
-                           }}
+                           onReady={handleWaveformReady}
+                           onFinish={handleWaveformFinish}
                         />
                      </div>
 
@@ -472,12 +482,8 @@ export function AudioPlayback({
                            waveColor="#9ca3af"
                            progressColor="#dc2626"
                            className="w-full"
-                           onReady={() => {
-                              // TODO: 音声準備完了時の処理を実装
-                           }}
-                           onFinish={() => {
-                              // TODO: 音声再生完了時の処理を実装
-                           }}
+                           onReady={handleWaveformReady}
+                           onFinish={handleWaveformFinish}
                         />
                      </div>
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Pull Request 概要

AI分析結果画面で波形がチカチカする問題を修正しました。WaveformPlayerコンポーネントに渡すコールバック関数をuseCallbackでメモ化することで、不要な再レンダリングを防止し、滑らかな波形表示を実現しました。

## 変更内容

- WaveformPlayerのコールバック関数をuseCallbackでメモ化
- onReady/onFinishハンドラーを安定化し不要な再レンダリングを防止
- formatRecordedAt/formatConfidenceも最適化
- 不安定な関数参照によるWaveSurfer再初期化を防止

## 動作確認

1. 音声を録音する
2. 「続ける」ボタンでAI分析を実行
3. AI分析結果画面で波形プレイヤーを確認
4. 波形がチカチカせずに滑らかに表示されることを確認

## 関連Issue

- Closes #119

## レビューポイント

- AudioPlaybackコンポーネントでのuseCallbackの使用方法
- WaveformPlayerの再レンダリング防止ロジック
- パフォーマンスの改善効果

## 変更内容サマリー

- **問題**: AI分析結果画面で波形がチカチカしていた
- **原因**: WaveformPlayerに渡すコールバック関数が毎回新しく作成され、WaveSurferが再初期化されていた
- **解決**: `useCallback`でコールバック関数をメモ化し、安定した関数参照を提供
- **効果**: 波形表示が滑らかになり、パフォーマンスも向上

## 技術的詳細

### 修正前の問題
```tsx
<WaveformPlayer
   onReady={() => {
      // TODO: 音声準備完了時の処理を実装
   }}
   onFinish={() => {
      // TODO: 音声再生完了時の処理を実装
   }}
/>
```

### 修正後の解決策
```tsx
const handleWaveformReady = useCallback(() => {
   // TODO: 音声準備完了時の処理を実装
}, [])

const handleWaveformFinish = useCallback(() => {
   // TODO: 音声再生完了時の処理を実装
}, [])

<WaveformPlayer
   onReady={handleWaveformReady}
   onFinish={handleWaveformFinish}
/>
```

### パフォーマンス向上
- WaveSurferの不要な再初期化を防止
- 安定した関数参照によりReactの再レンダリング最適化
- 全体的なUI応答性の向上

<!-- I want to review in Japanese. --> 