### PR TITLE
fix: 音声波形の再生時間表示が不安定な問題を修正

### DIFF
--- a/apps/web/src/components/molecules/WaveformPlayer/index.tsx
+++ b/apps/web/src/components/molecules/WaveformPlayer/index.tsx
@@ -203,22 +203,40 @@ export function WaveformPlayer({
 
          wavesurferRef.current = wavesurfer
 
+         // durationを安全に設定するヘルパー関数
+         const setDurationSafely = () => {
+            const duration = wavesurfer.getDuration()
+            if (Number.isFinite(duration) && duration > 0) {
+               setDuration(duration)
+               return true
+            }
+            return false
+         }
+
          // イベントリスナーを設定
          wavesurfer.on("ready", () => {
             setIsLoading(false)
             setIsInitialized(true)
-            const duration = wavesurfer.getDuration()
-            // durationが有効な値かチェック
-            if (Number.isFinite(duration) && duration > 0) {
-               setDuration(duration)
-            } else {
-               // durationが無効な場合は、デフォルト値を設定
-               setDuration(10) // 10秒のデフォルト値
-               console.warn(
-                  "WaveSurfer音声のdurationが無効です。デフォルト値を使用します:",
-                  duration,
-               )
+
+            // 即座にdurationを試行
+            if (!setDurationSafely()) {
+               // 少し遅延を入れてから再試行
+               setTimeout(() => {
+                  if (!setDurationSafely()) {
+                     // さらに遅延して最終試行
+                     setTimeout(() => {
+                        if (!setDurationSafely()) {
+                           // 最終的にデフォルト値を設定
+                           setDuration(10)
+                           console.warn(
+                              "WaveSurfer音声のdurationが取得できませんでした。デフォルト値を使用します。",
+                           )
+                        }
+                     }, 100)
+                  }
+               }, 50)
             }
+
             onReady?.()
             wavesurfer.play() // 再生を ready イベント内で確実に実行
          })
@@ -232,12 +250,12 @@ export function WaveformPlayer({
                }
 
                // 終了間近になったら手動で終了処理をトリガーする
-               const duration = wavesurfer.getDuration()
+               const audioDuration = wavesurfer.getDuration()
                if (
-                  Number.isFinite(duration) &&
-                  duration > 0 &&
+                  Number.isFinite(audioDuration) &&
+                  audioDuration > 0 &&
                   Number.isFinite(time) &&
-                  time >= duration - 0.05
+                  time >= audioDuration - 0.05
                ) {
                   // すでに再生が停止していなければ、手動で停止し、終了処理を呼び出す
                   if (wavesurfer.isPlaying()) {
@@ -259,12 +277,12 @@ export function WaveformPlayer({
                setCurrentTime(time)
             }
             // 終了間近になったら手動で終了処理をトリガーする
-            const duration = wavesurfer.getDuration()
+            const audioDuration = wavesurfer.getDuration()
             if (
-               Number.isFinite(duration) &&
-               duration > 0 &&
+               Number.isFinite(audioDuration) &&
+               audioDuration > 0 &&
                Number.isFinite(time) &&
-               time >= duration - 0.05
+               time >= audioDuration - 0.05
             ) {
                // すでに再生が停止していなければ、手動で停止し、終了処理を呼び出す
                if (wavesurfer.isPlaying()) {


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Pull Request 概要

音声波形の再生時間表示が10秒で固定されない不具合を修正しました。録音音声確認画面および音声分析結果画面で、波形の下に表示される再生時間が9秒になったり10秒になったりと不安定だった問題を解決し、実際の音声の長さを正確に表示するようにしました。

## 変更内容

- `WaveformPlayer`コンポーネントの`duration`取得処理を改善
- `setDurationSafely`ヘルパー関数を追加し、有効な値のみを設定
- 段階的な再試行メカニズムを実装（即座→50ms後→100ms後→フォールバック）
- `wavesurfer.getDuration()`を使用した実際の音声長に基づく終了判定に修正
- 音声読み込みの遅延に対応した安定性の向上

## 動作確認

1. 音声録音を実行し、録音音声確認画面を表示
2. 波形の下に表示される再生時間が実際の音声の長さ（例：9.5秒、10秒など）を正確に表示することを確認
3. 音声分析結果画面でも同様に正確な時間表示を確認
4. 複数回録音を行い、時間表示が安定していることを確認

## 関連Issue

- Closes #130

## レビューポイント

- `setDurationSafely`関数の実装とエラーハンドリング
- 段階的な再試行メカニズムの適切性
- `updateTime`と`audioprocess`イベントでの実際のduration使用
- TypeScriptの型安全性とlintルールの遵守

<!-- for GitHub Copilot review rule -->
<!--
[must]       → must fix (修正必須)
[suggestion]→ suggestion (提案)
[nit]        → nit (軽微な指摘)
[question]   → question (確認したい点)
[info]       → info (参考情報)
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. --> 