### PR TITLE
fix: マップピン配置後視点が自由に動かせるように修正

### DIFF
--- a/apps/web/src/components/organisms/MapComponent/hooks.ts
+++ b/apps/web/src/components/organisms/MapComponent/hooks.ts
@@ -354,6 +354,7 @@ export function useMapComponent({
    const userInteractionRef = useRef<boolean>(false)
    const lastInteractionTimeRef = useRef<number>(0)
    const userInteractionHandlerRef = useRef<(() => void) | null>(null)
+   const handledCreatedPinIdRef = useRef<string | null>(null)
 
    // 状態管理
    const [map, setMap] = useState<mapboxgl.Map | null>(null)
@@ -1033,6 +1034,11 @@ export function useMapComponent({
    useEffect(() => {
       if (!lastCreatedPinId || !map || !mapStyleLoaded) return
 
+      // 同じピンIDに対する重複flyToを防止
+      if (handledCreatedPinIdRef.current === lastCreatedPinId) {
+         return
+      }
+
       console.log(
          "🔄 新しいピンが作成されました。楽観的更新を実行:",
          lastCreatedPinId,
@@ -1045,7 +1051,6 @@ export function useMapComponent({
             pinId: newPin.id,
             location: { lat: newPin.latitude, lng: newPin.longitude },
          })
-
          map.flyTo({
             center: [newPin.longitude, newPin.latitude],
             zoom: 18,
@@ -1054,6 +1059,9 @@ export function useMapComponent({
             essential: true,
             duration: 1000,
          })
+
+         // このIDは処理済みとして記録
+         handledCreatedPinIdRef.current = lastCreatedPinId
       }
 
       // TanStack Queryのキャッシュを即座に無効化（遅延なし）


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Pull Request 概要

<!-- PR の目的・背景を簡潔に記載 -->
- マップにピンを配置後視点を移動しようとしたところ配置したピンの部分に視点が移動して、視点の移動が制限されたため。

## 変更内容

<!-- 行った変更・追加を箇条書きで記載 -->
- apps/web/src/components/organisms/MapComponent/hooks.ts を変更
- 直近に処理済みのピンIDを保持するための ref を追加
- 重複実行を防止するガードを追加
- flyTo 実行済みを記録、同じピンでの再実行を防止

## 動作確認

<!-- 該当箇所の動作確認手順やスクリーンショットなど -->
1. ピンを配置
2. カメラが設置したピンにフォーカスされる
3. 以降、カメラを自由に動かせる。

## 関連Issue

<!-- 関連する Issue 番号やリンクを記載 -->
- Closes #152 <issue_number> 

## レビューポイント

<!-- 特に見てほしい箇所や注意点 -->
- 

<!-- for GitHub Copilot review rule -->
<!--
[must]       → must fix (修正必須)
[suggestion]→ suggestion (提案)
[nit]        → nit (軽微な指摘)
[question]   → question (確認したい点)
[info]       → info (参考情報)
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->