### PR TITLE
feat(phase4): Supabase Queuesによる非同期音声分析機能の実装

### DIFF
--- a/apps/api/src/routes/audio.ts
+++ b/apps/api/src/routes/audio.ts
@@ -219,11 +219,12 @@ app.get("/:audioId/metadata", rateLimits.default, async (c) => {
 
 /**
  * POST /api/audio/:audioId/analyze
- * @description 音声ファイルをPython YAMNetで分析
+ * @description 音声分析ジョブを非同期で投入（Cloudflare Workers 30秒制限対応）
  * @tags Audio
  * @param {string} audioId - 分析する音声ファイルのID
- * @param {object} [options] - 分析オプション
- * @returns {AIAnalysisResult} AI分析結果
+ * @param {object} body - リクエストボディ
+ * @param {string} body.audioUrl - 分析対象の音声URL（公開アクセス可能）
+ * @returns {object} ジョブ投入結果とステータスURL
  */
 app.post("/:audioId/analyze", rateLimits.default, async (c) => {
    const audioService = new AudioService(
@@ -240,9 +241,8 @@ app.post("/:audioId/analyze", rateLimits.default, async (c) => {
          )
       }
 
-      // リクエストボディから分析オプションを取得
+      // リクエストボディから音声URLを取得
       const body = await c.req.json().catch(() => ({}))
-      const topK = body.topK || 5
       const audioUrl = body.audioUrl
 
       if (!audioUrl) {
@@ -253,40 +253,12 @@ app.post("/:audioId/analyze", rateLimits.default, async (c) => {
          )
       }
 
-      // Python YAMNetサービスで音声分析を実行
-      const pythonAnalysisResult = await audioService.analyzeAudioWithPython(
-         audioUrl,
-         topK,
-      )
-
-      // 分析結果を統一形式に変換
-      const analysisResult = {
-         transcription: "YAMNet音響分類完了",
-         categories: {
-            emotion: "N/A",
-            topic: pythonAnalysisResult.classifications[0]?.label || "環境音",
-            language: "N/A",
-            confidence:
-               pythonAnalysisResult.classifications[0]?.confidence || 0.0,
-         },
-         summary: `検出された音: ${
-            pythonAnalysisResult.classifications[0]?.label || "不明"
-         } (信頼度: ${Math.round(
-            (pythonAnalysisResult.classifications[0]?.confidence || 0) * 100,
-         )}%)`,
-         environment:
-            pythonAnalysisResult.environment?.primary_type || "unknown",
-         allClassifications: pythonAnalysisResult.classifications || [],
-         environmentDetails: pythonAnalysisResult.environment || {},
-         performanceMetrics: pythonAnalysisResult.performance_metrics || {},
-      }
-
-      // TODO: データベースに分析結果を保存
-      // await saveAnalysisResult(audioId, analysisResult)
+      // 非同期分析ジョブを投入
+      const jobResult = await audioService.scheduleAnalysis(audioId, audioUrl)
 
       return c.json({
          success: true,
-         data: analysisResult,
+         data: jobResult,
       })
    } catch (error) {
       if (error instanceof APIException) {
@@ -295,7 +267,96 @@ app.post("/:audioId/analyze", rateLimits.default, async (c) => {
 
       throw new APIException(
          ERROR_CODES.AI_ANALYSIS_FAILED,
-         "Failed to analyze audio",
+         "Failed to schedule audio analysis",
+         500,
+         error instanceof Error ? { message: error.message } : undefined,
+      )
+   }
+})
+
+/**
+ * GET /api/audio/:audioId/analysis/:jobId/status
+ * @description 分析ジョブのステータスと結果を取得
+ * @tags Audio
+ * @param {string} audioId - 音声ファイルのID
+ * @param {string} jobId - 分析ジョブのID
+ * @returns {object} ジョブステータスと分析結果
+ */
+app.get("/:audioId/analysis/:jobId/status", rateLimits.default, async (c) => {
+   const audioService = new AudioService(
+      c as unknown as Context<{ Bindings: Env }>,
+   )
+   const audioId = c.req.param("audioId")
+   const jobId = c.req.param("jobId")
+
+   try {
+      if (!audioId) {
+         throw new APIException(
+            ERROR_CODES.INVALID_AUDIO_FORMAT,
+            "Audio ID is required",
+            400,
+         )
+      }
+
+      if (!jobId) {
+         throw new APIException(
+            ERROR_CODES.INVALID_AUDIO_FORMAT,
+            "Job ID is required",
+            400,
+         )
+      }
+
+      // 分析ジョブのステータスを取得
+      const jobStatus = await audioService.getAnalysisStatus(jobId)
+
+      return c.json({
+         success: true,
+         data: jobStatus,
+      })
+   } catch (error) {
+      if (error instanceof APIException) {
+         throw error
+      }
+
+      throw new APIException(
+         ERROR_CODES.AI_ANALYSIS_FAILED,
+         "Failed to get analysis status",
+         500,
+         error instanceof Error ? { message: error.message } : undefined,
+      )
+   }
+})
+
+/**
+ * POST /api/audio/internal/process-queue
+ * @description キューから分析ジョブを取得して処理（内部用・Cron Trigger用）
+ * @tags Internal
+ * @returns {object} 処理結果
+ */
+app.post("/internal/process-queue", async (c) => {
+   const audioService = new AudioService(
+      c as unknown as Context<{ Bindings: Env }>,
+   )
+
+   try {
+      // キューから分析ジョブを処理
+      const processedCount = await audioService.processAnalysisQueue()
+
+      return c.json({
+         success: true,
+         data: {
+            processedCount,
+            message: `Processed ${processedCount} analysis jobs`,
+         },
+      })
+   } catch (error) {
+      if (error instanceof APIException) {
+         throw error
+      }
+
+      throw new APIException(
+         ERROR_CODES.AI_ANALYSIS_FAILED,
+         "Failed to process analysis queue",
          500,
          error instanceof Error ? { message: error.message } : undefined,
       )

--- a/apps/api/src/services/audio.service.ts
+++ b/apps/api/src/services/audio.service.ts
@@ -26,6 +26,76 @@ interface PythonAnalysisResult {
 }
 
 /**
+ * 分析ジョブのステータス型
+ */
+type AnalysisJobStatus = "queued" | "processing" | "completed" | "failed"
+
+/**
+ * 分析ジョブの結果型
+ */
+interface AnalysisJobResult {
+   jobId: string
+   status: AnalysisJobStatus
+   estimatedDuration?: string
+   statusUrl: string
+}
+
+/**
+ * 分析ジョブステータスレスポンス型
+ */
+interface AnalysisJobStatusResponse {
+   jobId: string
+   status: AnalysisJobStatus
+   result?: PythonAnalysisResult
+   error?: {
+      message: string
+      code?: string
+   }
+   createdAt: string
+   startedAt?: string
+   completedAt?: string
+   retryCount: number
+}
+
+/**
+ * Supabase Queues (pgmq) のメッセージ型
+ */
+interface QueueMessage {
+   audioId: string
+   audioUrl: string
+   retryCount?: number
+   metadata?: Record<string, unknown>
+}
+
+/**
+ * Supabase Queuesから読み取ったメッセージ型
+ */
+interface QueueReadMessage {
+   msg_id: number
+   read_ct: number
+   enqueued_at: string
+   vt: string
+   message: QueueMessage
+}
+
+/**
+ * 分析結果テーブルのレコード型
+ */
+interface AnalysisResultRecord {
+   message_id: number
+   audio_id: string
+   status: AnalysisJobStatus
+   result: PythonAnalysisResult | null
+   error_message: string | null
+   error_code: string | null
+   retry_count: number
+   created_at: string
+   started_at: string | null
+   completed_at: string | null
+   metadata: Record<string, unknown> | null
+}
+
+/**
  * 音声ファイル処理サービス
  *
  * @description
@@ -37,6 +107,9 @@ export class AudioService extends BaseService {
    private readonly maxFileSize = 10 * 1024 * 1024 // 10MB
    private readonly maxDuration = 600 // 10 minutes
    private readonly allowedFormats = ["webm", "mp3", "wav"] as const
+   private readonly queueName = "audio-analysis"
+   private readonly maxRetries = 3
+   private readonly visibilityTimeout = 60 // 60秒
 
    protected getServiceName(): string {
       return "AudioService"
@@ -408,6 +481,379 @@ export class AudioService extends BaseService {
       }
 
       return formatMap[extension] || "webm"
+   }
+
+   /**
+    * 音声分析ジョブをSupabase Queuesに投入（非同期）
+    * Cloudflare Workersの30秒制限に対応した非同期処理
+    *
+    * @param audioId - 分析対象の音声ID
+    * @param audioUrl - 分析対象の音声URL（公開アクセス可能）
+    * @returns 分析ジョブの情報
+    */
+   async scheduleAnalysis(
+      audioId: string,
+      audioUrl: string,
+   ): Promise<AnalysisJobResult> {
+      try {
+         this.log("info", "Scheduling audio analysis job", {
+            audioId,
+            audioUrl,
+         })
+
+         // Supabase Queuesにメッセージを送信
+         const message: QueueMessage = {
+            audioId,
+            audioUrl,
+            retryCount: 0,
+         }
+
+         // queue_nameに指定されたキューにメッセージを追加する
+         // sleep_secondsはオプショナルで表示されるまでの秒数を指定できる
+         const { data, error } = await this.supabaseClient.rpc("queue_send", {
+            queue_name: this.queueName,
+            message: message,
+            sleep_seconds: 0,
+         })
+
+         if (error) {
+            this.log("error", "Failed to send message to queue", {
+               error: error.message,
+               audioId,
+            })
+            throw new APIException(
+               ERROR_CODES.AI_ANALYSIS_FAILED,
+               `Failed to schedule analysis: ${error.message}`,
+               500,
+            )
+         }
+
+         const messageId = data as number
+         const statusUrl = `/api/audio/${audioId}/analysis/${messageId}/status`
+
+         this.log("info", "Analysis job scheduled successfully", {
+            messageId,
+            audioId,
+            statusUrl,
+         })
+
+         return {
+            jobId: String(messageId),
+            status: "queued",
+            estimatedDuration: "15-30 seconds",
+            statusUrl,
+         }
+      } catch (error) {
+         this.log("error", "Failed to schedule analysis job", {
+            audioId,
+            error: error instanceof Error ? error.message : String(error),
+         })
+
+         if (error instanceof APIException) {
+            throw error
+         }
+
+         throw new APIException(
+            ERROR_CODES.AI_ANALYSIS_FAILED,
+            "Failed to schedule audio analysis",
+            500,
+            error instanceof Error ? { message: error.message } : undefined,
+         )
+      }
+   }
+
+   /**
+    * 分析ジョブのステータスを取得
+    *
+    * @param messageId - Supabase QueuesのメッセージID
+    * @returns ジョブのステータスと結果
+    */
+   async getAnalysisStatus(
+      messageId: string,
+   ): Promise<AnalysisJobStatusResponse> {
+      try {
+         this.log("info", "Fetching analysis job status", { messageId })
+
+         const messageIdNum = Number.parseInt(messageId, 10)
+
+         if (Number.isNaN(messageIdNum)) {
+            throw new APIException(
+               ERROR_CODES.AI_ANALYSIS_FAILED,
+               "Invalid message ID",
+               400,
+            )
+         }
+
+         // 分析結果テーブルから結果を取得
+         const { data: result } = await this.supabaseClient
+            .from("analysis_results")
+            .select("*")
+            .eq("message_id", messageIdNum)
+            .maybeSingle()
+
+         // 結果が存在する場合（処理済み）
+         if (result) {
+            const analysisResult = result as AnalysisResultRecord
+
+            const response: AnalysisJobStatusResponse = {
+               jobId: String(analysisResult.message_id),
+               status: analysisResult.status,
+               createdAt: analysisResult.created_at,
+               retryCount: analysisResult.retry_count,
+            }
+
+            // オプショナルなフィールドを条件付きで追加
+            if (analysisResult.started_at) {
+               response.startedAt = analysisResult.started_at
+            }
+            if (analysisResult.completed_at) {
+               response.completedAt = analysisResult.completed_at
+            }
+
+            // 完了時は結果を含める
+            if (
+               analysisResult.status === "completed" &&
+               analysisResult.result
+            ) {
+               response.result = analysisResult.result
+            }
+
+            // エラー時はエラー情報を含める
+            if (
+               analysisResult.status === "failed" &&
+               analysisResult.error_message
+            ) {
+               response.error = {
+                  message: analysisResult.error_message,
+               }
+               if (analysisResult.error_code) {
+                  response.error.code = analysisResult.error_code
+               }
+            }
+
+            this.log("info", "Analysis job status fetched from results table", {
+               messageId,
+               status: analysisResult.status,
+            })
+
+            return response
+         }
+
+         // 結果がない場合、キューにメッセージが残っているか確認
+         // NOTE: pgmq_public.readはクライアント側から直接呼び出せないため、
+         // 結果テーブルにレコードがない場合は"queued"として扱う
+         this.log("info", "Analysis job still in queue", { messageId })
+
+         return {
+            jobId: messageId,
+            status: "queued",
+            createdAt: new Date().toISOString(),
+            retryCount: 0,
+         }
+      } catch (error) {
+         this.log("error", "Failed to fetch analysis job status", {
+            messageId,
+            error: error instanceof Error ? error.message : String(error),
+         })
+
+         if (error instanceof APIException) {
+            throw error
+         }
+
+         throw new APIException(
+            ERROR_CODES.AI_ANALYSIS_FAILED,
+            "Failed to fetch analysis status",
+            500,
+            error instanceof Error ? { message: error.message } : undefined,
+         )
+      }
+   }
+
+   /**
+    * キューから分析ジョブを取得して実行（Worker/Cron用）
+    * この関数は定期的に実行され、キュー内のジョブを処理します
+    *
+    * @returns 処理されたジョブの数
+    */
+   async processAnalysisQueue(): Promise<number> {
+      try {
+         this.log("info", "Starting analysis queue processing")
+
+         // queue_nameに指定されたキューからメッセージを読み取る
+         // sleep_secondsはオプショナルで表示されるまでの秒数を指定できる
+         // nは読み取るメッセージの最大数を指定できる
+         const { data: messages, error } = await this.supabaseClient.rpc(
+            "queue_read",
+            {
+               queue_name: this.queueName,
+               sleep_seconds: this.visibilityTimeout,
+               n: 3,
+            },
+         )
+
+         if (error) {
+            this.log("error", "Failed to read messages from queue", {
+               error: error.message,
+            })
+            return 0
+         }
+
+         if (!messages || messages.length === 0) {
+            this.log("info", "No messages found in queue")
+            return 0
+         }
+
+         const queueMessages = messages as QueueReadMessage[]
+         let processedCount = 0
+
+         // 各メッセージを並行処理
+         await Promise.all(
+            queueMessages.map(async (msg) => {
+               try {
+                  await this.executeAnalysisJob(msg)
+                  processedCount++
+               } catch (error) {
+                  this.log("error", "Failed to execute analysis job", {
+                     messageId: msg.msg_id,
+                     error:
+                        error instanceof Error ? error.message : String(error),
+                  })
+               }
+            }),
+         )
+
+         this.log("info", "Analysis queue processing completed", {
+            processedCount,
+            totalMessages: queueMessages.length,
+         })
+
+         return processedCount
+      } catch (error) {
+         this.log("error", "Analysis queue processing failed", {
+            error: error instanceof Error ? error.message : String(error),
+         })
+         return 0
+      }
+   }
+
+   /**
+    * 個別の分析ジョブを実行
+    *
+    * @param queueMessage - 実行するキューメッセージ
+    */
+   private async executeAnalysisJob(
+      queueMessage: QueueReadMessage,
+   ): Promise<void> {
+      const messageId = queueMessage.msg_id
+      const message = queueMessage.message
+      const retryCount = message.retryCount || 0
+
+      try {
+         // 分析結果テーブルに処理中レコードを挿入
+         await this.supabaseClient.from("analysis_results").upsert({
+            message_id: messageId,
+            audio_id: message.audioId,
+            status: "processing",
+            retry_count: retryCount,
+            started_at: new Date().toISOString(),
+         })
+
+         this.log("info", "Executing analysis job", {
+            messageId,
+            audioId: message.audioId,
+            audioUrl: message.audioUrl,
+         })
+
+         // Python YAMNet分析を実行
+         const analysisResult = await this.analyzeAudioWithPython(
+            message.audioUrl,
+            5,
+         )
+
+         // 分析結果を更新
+         await this.supabaseClient
+            .from("analysis_results")
+            .update({
+               status: "completed",
+               result: analysisResult,
+               completed_at: new Date().toISOString(),
+            })
+            .eq("message_id", messageId)
+
+         // キューからメッセージを削除
+         await this.supabaseClient.rpc("queue_delete", {
+            queue_name: this.queueName,
+            message_id: messageId,
+         })
+
+         this.log("info", "Analysis job completed successfully", {
+            messageId,
+            audioId: message.audioId,
+         })
+      } catch (error) {
+         const errorMessage =
+            error instanceof Error ? error.message : String(error)
+         const errorCode =
+            error instanceof APIException
+               ? error.code
+               : ERROR_CODES.AI_ANALYSIS_FAILED
+
+         this.log("error", "Analysis job execution failed", {
+            messageId,
+            error: errorMessage,
+            retryCount,
+         })
+
+         // リトライ可能かチェック
+         const canRetry = retryCount < this.maxRetries
+
+         if (canRetry) {
+            // メッセージを再キュー（リトライカウント増加）
+            const retryMessage: QueueMessage = {
+               ...message,
+               retryCount: retryCount + 1,
+            }
+
+            await this.supabaseClient.rpc("queue_send", {
+               queue_name: this.queueName,
+               message: retryMessage,
+               sleep_seconds: 10, // 10秒後に再試行
+            })
+
+            // 元のメッセージを削除
+            await this.supabaseClient.rpc("queue_delete", {
+               queue_name: this.queueName,
+               message_id: messageId,
+            })
+
+            this.log("info", "Analysis job re-queued for retry", {
+               messageId,
+               retryCount: retryCount + 1,
+            })
+         } else {
+            // 最大リトライ回数に達したら失敗として記録
+            await this.supabaseClient.from("analysis_results").upsert({
+               message_id: messageId,
+               audio_id: message.audioId,
+               status: "failed",
+               error_message: errorMessage,
+               error_code: errorCode,
+               retry_count: retryCount,
+               completed_at: new Date().toISOString(),
+            })
+
+            // キューからメッセージを削除
+            await this.supabaseClient.rpc("queue_delete", {
+               queue_name: this.queueName,
+               message_id: messageId,
+            })
+
+            this.log("error", "Analysis job failed after max retries", {
+               messageId,
+               retryCount,
+            })
+         }
+      }
    }
 
    /**


### PR DESCRIPTION
## Pull Request 概要

Cloudflare Workersの30秒CPU時間制限に対応するため、音声分析を非同期ジョブとして実行する仕組みを実装
Supabase Queues (pgmq)で長時間処理をキューベースの非同期アーキテクチャに移行

## 変更内容

### API実装（audio.ts）
  - `POST /api/audio/:audioId/analyze` - 分析ジョブをキューに投入
  - `GET /api/audio/:audioId/analysis/:jobId/status` - ジョブステータス・結果取得
  - `POST /api/audio/internal/process-queue` - キュー処理（Cron Trigger用）

### サービス実装（audio.service.ts）
  - **scheduleAnalysis()**: 分析ジョブをSupabase Queuesに投入
  - **getAnalysisStatus()**: analysis_resultsテーブルから状態・結果取得
  - **processAnalysisQueue()**: キューから最大3件のジョブを取得・処理
  - **executeAnalysisJob()**: Python YAMNet分析実行とリトライ管理

## 動作確認

### 1. ジョブ投入API
  ```bash
  curl -X POST 'http://localhost:8787/api/audio/TEST-AUDIO/analyze' \
    -H 'Content-Type: application/json' \
    -d '{"audioUrl": "https://example.com/test.webm"}'
  ```
  結果: ✅ jobId "3" 正常発行、status "queued"

### 2. ステータス取得API
  ```bash
  curl http://localhost:8787/api/audio/TEST-AUDIO/analysis/3/status
  ```
  結果: ✅ ステータス "queued" 正常取得

### 3. キュー処理API
  ```bash
  curl -X POST http://localhost:8787/api/audio/internal/process-queue
  ```
  結果: ✅ 2件のジョブ正常処理

### 関連Issue
- なし
### レビューポイント
- なし