### PR TITLE
feature: backlogラベル自動化ciの追加

### DIFF
--- a/.github/workflows/backlog-automation.yml
+++ b/.github/workflows/backlog-automation.yml
@@ -1,0 +1,102 @@
+name: Backlog Automation
+
+on:
+  issues:
+    types: [labeled]
+
+env:
+  PROJECT_URL: https://github.com/users/Ojoxux/projects/1
+  PROGRESS_LABELS: '["todo", "in progress", "review", "done"]'
+
+jobs:
+  move-to-backlog:
+    # backlogラベルが追加されたときのみ実行
+    if: github.event.label.name == 'backlog'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    
+    steps:
+      - name: Remove progress labels
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const progressLabels = JSON.parse(process.env.PROGRESS_LABELS);
+            
+            // 現在のIssueラベルを取得
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            
+            const currentLabels = issue.labels.map(label => label.name);
+            const progressLabelsToRemove = currentLabels.filter(label => 
+              progressLabels.includes(label)
+            );
+            
+            // 進捗ラベルをすべて削除
+            for (const label of progressLabelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: label
+              });
+              console.log(`🗑️ Removed progress label '${label}' from issue #${context.issue.number}`);
+            }
+            
+            if (progressLabelsToRemove.length === 0) {
+              console.log(`ℹ️ No progress labels to remove from issue #${context.issue.number}`);
+            } else {
+              console.log(`✅ Removed ${progressLabelsToRemove.length} progress label(s) from issue #${context.issue.number}`);
+            }
+
+      - name: Get Project Item ID
+        id: get-item
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PROJECT_PAT }}
+          script: |
+            const query = `
+              query($owner: String!, $repo: String!, $issue_number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $issue_number) {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id title }
+                      }
+                    }
+                  }
+                }
+              }
+            `;
+            const variables = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            };
+            const result = await github.graphql(query, variables);
+            const projectItems = result.repository.issue.projectItems.nodes;
+            
+            if (projectItems.length > 0) {
+              console.log(`✅ Found project item for issue #${context.issue.number}`);
+              return projectItems[0].id;
+            }
+            
+            console.log(`⚠️ No project item found for issue #${context.issue.number}`);
+            return null;
+
+      - name: Move to Backlog Column
+        if: steps.get-item.outputs.result
+        uses: titoportas/update-project-fields@v0.1.0
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.PROJECT_PAT }}
+          item-id: ${{ steps.get-item.outputs.result }}
+          field-keys: Status
+          field-values: "🗂️ バックログ"
+

--- a/.github/workflows/label-sync-automation.yml
+++ b/.github/workflows/label-sync-automation.yml
@@ -68,15 +68,22 @@ jobs:
             
             // ラベル削除の場合
             if (context.payload.action === 'unlabeled') {
-              // 進捗ラベルが全くない場合、デフォルトで'todo'を追加
+              // 進捗ラベルが全くない場合、backlogラベルがなければデフォルトで'todo'を追加
               if (currentProgressLabels.length === 0) {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  labels: ['todo']
-                });
-                console.log(`✅ Added default 'todo' label to issue #${context.issue.number} (no progress labels)`);
+                // backlogラベルが存在する場合はtodoを自動追加しない
+                const hasBacklogLabel = currentLabels.includes('backlog');
+                
+                if (!hasBacklogLabel) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    labels: ['todo']
+                  });
+                  console.log(`✅ Added default 'todo' label to issue #${context.issue.number} (no progress labels)`);
+                } else {
+                  console.log(`ℹ️ Skipped adding 'todo' label to issue #${context.issue.number} (has 'backlog' label)`);
+                }
               }
             }
 


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Pull Request 概要

<!-- PR の目的・背景を簡潔に記載 -->
Issueに`backlog`ラベルを付与したら自動的にバックログカラムに遷移するワークフロー構築

## 変更内容

<!-- 行った変更・追加を箇条書きで記載 -->
- backlogラベル追加時に自動でtodoラベルが再アタッチされないように修正
- backlogラベル追加時にプロジェクトのバックログカラムに自動移動する機能を追加
- 進捗ラベル削除時のbacklogラベルチェック処理を追加

## 関連Issue

<!-- 関連する Issue 番号やリンクを記載 -->
- Closes #112 

<!-- for GitHub Copilot review rule -->
<!--
[must]       → must fix (修正必須)
[suggestion]→ suggestion (提案)
[nit]        → nit (軽微な指摘)
[question]   → question (確認したい点)
[info]       → info (参考情報)
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->