### PR TITLE
fix: OpenAPI型統一と未認証ピン作成・音声推論を復旧

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ CORS_ORIGIN=http://localhost:3000
 
 # Python Audio Analyzer設定
 PYTHON_AUDIO_ANALYZER_URL=http://python-api:8000
-PYTHON_AUDIO_ANALYZER_TIMEOUT=30000
+PYTHON_AUDIO_ANALYZER_TIMEOUT=120000
 
 # Redis設定（必要に応じて）
 REDIS_URL=redis://redis:6379

--- a/apps/api/.dev.vars.example
+++ b/apps/api/.dev.vars.example
@@ -11,7 +11,7 @@ CORS_ORIGIN=http://localhost:3000
 # Python Audio Analyzer (YAMNet)
 # ローカル開発環境用
 PYTHON_AUDIO_ANALYZER_URL=http://localhost:8000
-PYTHON_AUDIO_ANALYZER_TIMEOUT=30000
+PYTHON_AUDIO_ANALYZER_TIMEOUT=120000
 
 # 環境設定
 ENVIRONMENT=development

--- a/apps/api/src/routes/audio.ts
+++ b/apps/api/src/routes/audio.ts
@@ -1,5 +1,14 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import { ERROR_CODES } from "@sonory/shared-types"
+import {
+   AnalysisJobResultSchema,
+   AnalysisStatusSchema,
+   ApiErrorResponseSchema,
+   ApiSuccessResponseSchema,
+   AudioMetadataSchema,
+   AudioUploadResultSchema,
+   ERROR_CODES,
+   UploadUrlDataSchema,
+} from "@sonory/shared-types"
 import type { Context } from "hono"
 import type { Env } from "../index"
 import { APIException } from "../middleware/error"
@@ -11,113 +20,16 @@ const app = new OpenAPIHono<{ Bindings: Env }>({
    defaultHook: onOpenAPIValidationError,
 })
 
-const audioFormatSchema = z.enum([
-   "webm",
-   "mp3",
-   "wav",
-   "mp4",
-   "m4a",
-   "flac",
-   "ogg",
-])
-
-const audioMetadataSchema = z.object({
-   id: z.string(),
-   filename: z.string(),
-   size: z.number(),
-   format: audioFormatSchema,
-   duration: z.number(),
-   url: z.string().optional(),
-   uploadedAt: z.string(),
-})
-
-const uploadUrlDataSchema = z.object({
-   uploadUrl: z.string(),
-   filePath: z.string(),
-   expiresAt: z.string(),
-   maxFileSize: z.number(),
-})
-
-const audioUploadResultSchema = z.object({
-   audioId: z.string(),
-   audioUrl: z.string(),
-   audioFilePath: z.string(),
-   metadata: audioMetadataSchema,
-})
-
-const analysisJobResultSchema = z.object({
-   jobId: z.string(),
-   status: z.enum(["queued", "processing", "completed", "failed"]),
-   estimatedDuration: z.string().optional(),
-   statusUrl: z.string(),
-})
-
-const pythonAnalysisResultSchema = z.object({
-   classifications: z.array(
-      z.object({
-         label: z.string(),
-         confidence: z.number(),
-      }),
-   ),
-   environment: z
-      .object({
-         primary_type: z.string(),
-         type_scores: z.record(z.string(), z.number()),
-         description: z.string(),
-      })
-      .optional(),
-   performance_metrics: z
-      .object({
-         yamnet_inference_time: z.number(),
-         total_time: z.number(),
-         processing_ratio: z.number(),
-      })
-      .optional(),
-})
-
-const analysisStatusSchema = z.object({
-   jobId: z.string(),
-   status: z.enum(["queued", "processing", "completed", "failed"]),
-   result: pythonAnalysisResultSchema.optional(),
-   error: z
-      .object({
-         message: z.string(),
-         code: z.string().optional(),
-      })
-      .optional(),
-   createdAt: z.string(),
-   startedAt: z.string().optional(),
-   completedAt: z.string().optional(),
-   retryCount: z.number(),
-})
-
-const errorResponseSchema = z.object({
-   success: z.literal(false),
-   error: z.object({
-      code: z.string(),
-      message: z.string(),
-      details: z.unknown().optional(),
-      timestamp: z.string(),
-      requestId: z.string(),
-   }),
-})
-
 const standardErrorResponses = {
    400: {
-      content: { "application/json": { schema: errorResponseSchema } },
+      content: { "application/json": { schema: ApiErrorResponseSchema } },
       description: "リクエスト不正",
    },
    500: {
-      content: { "application/json": { schema: errorResponseSchema } },
+      content: { "application/json": { schema: ApiErrorResponseSchema } },
       description: "サーバーエラー",
    },
 }
-
-const successResponseSchema = <T extends z.ZodType>(data: T) =>
-   z.object({
-      success: z.literal(true),
-      data,
-   })
 
 const deleteAudioData = async (
    c: Context<{ Bindings: Env }>,
@@ -182,7 +94,7 @@ const uploadUrlRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(uploadUrlDataSchema),
+               schema: ApiSuccessResponseSchema(UploadUrlDataSchema),
             },
          },
          description: "Presigned URLと関連情報",
@@ -215,7 +127,7 @@ const uploadRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(audioUploadResultSchema),
+               schema: ApiSuccessResponseSchema(AudioUploadResultSchema),
             },
          },
          description: "アップロード結果",
@@ -240,7 +152,7 @@ const deleteAudioRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(
+               schema: ApiSuccessResponseSchema(
                   z.object({
                      deleted: z.boolean(),
                      deletedPath: z.string(),
@@ -270,7 +182,7 @@ const getAudioMetadataRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(audioMetadataSchema),
+               schema: ApiSuccessResponseSchema(AudioMetadataSchema),
             },
          },
          description: "メタデータ",
@@ -307,7 +219,7 @@ const analyzeAudioRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(analysisJobResultSchema),
+               schema: ApiSuccessResponseSchema(AnalysisJobResultSchema),
             },
          },
          description: "ジョブ投入結果とステータスURL",
@@ -333,7 +245,7 @@ const analysisStatusRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(analysisStatusSchema),
+               schema: ApiSuccessResponseSchema(AnalysisStatusSchema),
             },
          },
          description: "ジョブステータスと分析結果",
@@ -352,7 +264,7 @@ const processQueueRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(
+               schema: ApiSuccessResponseSchema(
                   z.object({
                      processedCount: z.number(),
                      message: z.string(),

--- a/apps/api/src/routes/pins.ts
+++ b/apps/api/src/routes/pins.ts
@@ -1,8 +1,17 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import {
+   ApiErrorResponseSchema,
+   ApiSuccessResponseSchema,
+   ApiSuccessWithMetaResponseSchema,
+   CreatePinRequestSchema,
    ERROR_CODES,
+   NearbyPinsQueryParamsSchema,
+   ReportPinRequestSchema,
+   SearchPinsQueryParamsSchema,
+   SoundPinApiSchema,
    type NearbyPinsQuery,
    type SearchPinsQuery,
+   UpdatePinRequestSchema,
 } from "@sonory/shared-types"
 import { APIException } from "../middleware/error"
 import { onOpenAPIValidationError } from "../middleware/validation"
@@ -17,156 +26,23 @@ const app = new OpenAPIHono<{ Bindings: Env }>({
    defaultHook: onOpenAPIValidationError,
 })
 
-const weatherSchema = z.object({
-   temperature: z.number(),
-   condition: z.string().optional().nullable(),
-   windSpeed: z.number().optional().nullable(),
-   humidity: z.number().min(0).max(100).optional().nullable(),
-})
-
-const aiAnalysisSchema = z.object({
-   transcription: z.string(),
-   categories: z.object({
-      emotion: z.string(),
-      topic: z.string(),
-      language: z.string(),
-      confidence: z.number().min(0).max(1),
-   }),
-   summary: z.string().optional(),
-})
-
-const soundPinSchema = z.object({
-   id: z.string(),
-   userId: z.string().optional(),
-   location: z.object({
-      lat: z.number(),
-      lng: z.number(),
-      accuracy: z.number().positive().optional(),
-   }),
-   audio: z.object({
-      url: z.string(),
-      duration: z.number(),
-      format: z.enum(["webm", "mp3", "wav", "mp4", "m4a", "flac", "ogg"]),
-   }),
-   weather: weatherSchema.optional(),
-   timeTag: z.enum(["朝", "昼", "夕", "夜"]).optional(),
-   aiAnalysis: aiAnalysisSchema.optional(),
-   status: z.enum(["active", "processing", "deleted", "reported"]),
-   title: z.string().optional(),
-   metadata: z
-      .object({
-         deviceInfo: z.string().optional(),
-      })
-      .optional(),
-   createdAt: z.string(),
-   updatedAt: z.string(),
-})
-
-const errorResponseSchema = z.object({
-   success: z.literal(false),
-   error: z.object({
-      code: z.string(),
-      message: z.string(),
-      details: z.unknown().optional(),
-      timestamp: z.string(),
-      requestId: z.string(),
-   }),
-})
-
 const standardErrorResponses = {
    400: {
-      content: { "application/json": { schema: errorResponseSchema } },
+      content: { "application/json": { schema: ApiErrorResponseSchema } },
       description: "リクエスト不正",
    },
    404: {
-      content: { "application/json": { schema: errorResponseSchema } },
+      content: { "application/json": { schema: ApiErrorResponseSchema } },
       description: "対象が見つからない",
    },
    500: {
-      content: { "application/json": { schema: errorResponseSchema } },
+      content: { "application/json": { schema: ApiErrorResponseSchema } },
       description: "サーバーエラー",
    },
 }
 
-const successResponseSchema = <T extends z.ZodType>(data: T) =>
-   z.object({
-      success: z.literal(true),
-      data,
-   })
-
-const successWithMetaResponseSchema = <T extends z.ZodType>(data: T) =>
-   z.object({
-      success: z.literal(true),
-      data,
-      meta: z.record(z.string(), z.unknown()).optional(),
-   })
-
-/**
- * Request validation schemas
- */
-const createPinSchema = z.object({
-   userId: z.string().uuid().optional(),
-   location: z.object({
-      lat: z.number().min(-90).max(90),
-      lng: z.number().min(-180).max(180),
-      accuracy: z.number().positive().optional(),
-   }),
-   audio: z
-      .object({
-         url: z.string().url(),
-         duration: z.number().min(9.9).max(600),
-         format: z.enum(["webm", "mp3", "wav"]),
-      })
-      .optional(),
-   audio_file_path: z.string().optional(),
-   metadata: z
-      .object({
-         duration: z.number().positive().optional(),
-         timeTag: z.enum(["朝", "昼", "夕", "夜"]).optional(),
-         title: z.string().max(200).optional(),
-         deviceInfo: z.string().optional(),
-         weather: weatherSchema.optional(),
-      })
-      .optional(),
-   weather: weatherSchema.optional(),
-   timeTag: z.enum(["朝", "昼", "夕", "夜"]).optional(),
-   title: z.string().max(200).optional(),
-   deviceInfo: z.string().optional(),
-})
-
-const updatePinSchema = z.object({
-   title: z.string().max(200).optional(),
-   status: z.enum(["active", "processing", "deleted", "reported"]).optional(),
-   aiAnalysis: aiAnalysisSchema.optional(),
-})
-
-const nearbyPinsSchema = z.object({
-   north: z.coerce.number().min(-90).max(90),
-   south: z.coerce.number().min(-90).max(90),
-   east: z.coerce.number().min(-180).max(180),
-   west: z.coerce.number().min(-180).max(180),
-   limit: z.coerce.number().positive().max(100).optional(),
-   categories: z.array(z.string()).optional(),
-})
-
-const searchPinsSchema = z.object({
-   lat: z.coerce.number().min(-90).max(90).optional(),
-   lng: z.coerce.number().min(-180).max(180).optional(),
-   radius: z.coerce.number().positive().optional(),
-   startTime: z.string().datetime().optional(),
-   endTime: z.string().datetime().optional(),
-   categories: z.array(z.string()).optional(),
-   weather: z.array(z.string()).optional(),
-   limit: z.coerce.number().positive().max(100).optional(),
-   offset: z.coerce.number().nonnegative().optional(),
-})
-
-const reportPinSchema = z.object({
-   reason: z.string().min(10).max(1000),
-})
-
 // HACK: 複雑な配列スキーマは事前に定義して型推論の深さを抑える
-const createPinsBatchSchema: z.ZodTypeAny = z.array(createPinSchema)
+const createPinsBatchSchema: z.ZodTypeAny = z.array(CreatePinRequestSchema)
 
 /**
  * Route definitions
@@ -181,7 +57,7 @@ const createPinRoute = createRoute({
       body: {
          required: true,
          content: {
-            "application/json": { schema: createPinSchema },
+            "application/json": { schema: CreatePinRequestSchema },
          },
       },
    },
@@ -189,7 +65,7 @@ const createPinRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(soundPinSchema),
+               schema: ApiSuccessResponseSchema(SoundPinApiSchema),
             },
          },
          description: "作成されたピン",
@@ -222,7 +98,7 @@ const uploadPinRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(soundPinSchema),
+               schema: ApiSuccessResponseSchema(SoundPinApiSchema),
             },
          },
          description: "作成されたピン",
@@ -238,13 +114,13 @@ const nearbyPinsRoute = createRoute({
    summary: "周辺ピン取得",
    description: "指定された境界内のピンを取得",
    request: {
-      query: nearbyPinsSchema,
+      query: NearbyPinsQueryParamsSchema,
    },
    responses: {
       200: {
          content: {
             "application/json": {
-               schema: successWithMetaResponseSchema(z.array(soundPinSchema)),
+               schema: ApiSuccessWithMetaResponseSchema(z.array(SoundPinApiSchema)),
             },
          },
          description: "周辺ピン一覧",
@@ -260,13 +136,13 @@ const searchPinsRoute = createRoute({
    summary: "ピン検索",
    description: "条件を指定してピンを検索",
    request: {
-      query: searchPinsSchema,
+      query: SearchPinsQueryParamsSchema,
    },
    responses: {
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(z.array(soundPinSchema)),
+               schema: ApiSuccessResponseSchema(z.array(SoundPinApiSchema)),
             },
          },
          description: "検索結果",
@@ -290,7 +166,7 @@ const getUserPinsRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(z.array(soundPinSchema)),
+               schema: ApiSuccessResponseSchema(z.array(SoundPinApiSchema)),
             },
          },
          description: "ユーザーのピン一覧",
@@ -319,7 +195,7 @@ const batchCreatePinsRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successWithMetaResponseSchema(z.array(soundPinSchema)),
+               schema: ApiSuccessWithMetaResponseSchema(z.array(SoundPinApiSchema)),
             },
          },
          description: "作成されたピン一覧",
@@ -343,7 +219,7 @@ const getPinByIdRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(soundPinSchema),
+               schema: ApiSuccessResponseSchema(SoundPinApiSchema),
             },
          },
          description: "ピン詳細",
@@ -365,7 +241,7 @@ const updatePinRoute = createRoute({
       body: {
          required: true,
          content: {
-            "application/json": { schema: updatePinSchema },
+            "application/json": { schema: UpdatePinRequestSchema },
          },
       },
    },
@@ -373,7 +249,7 @@ const updatePinRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(soundPinSchema),
+               schema: ApiSuccessResponseSchema(SoundPinApiSchema),
             },
          },
          description: "更新されたピン",
@@ -397,7 +273,7 @@ const deletePinRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(
+               schema: ApiSuccessResponseSchema(
                   z.object({ deleted: z.boolean() }),
                ),
             },
@@ -421,7 +297,7 @@ const reportPinRoute = createRoute({
       body: {
          required: true,
          content: {
-            "application/json": { schema: reportPinSchema },
+            "application/json": { schema: ReportPinRequestSchema },
          },
       },
    },
@@ -429,7 +305,7 @@ const reportPinRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: successResponseSchema(
+               schema: ApiSuccessResponseSchema(
                   z.object({ reported: z.boolean() }),
                ),
             },

--- a/apps/api/src/routes/pins.ts
+++ b/apps/api/src/routes/pins.ts
@@ -5,12 +5,12 @@ import {
    ApiSuccessWithMetaResponseSchema,
    CreatePinRequestSchema,
    ERROR_CODES,
+   type NearbyPinsQuery,
    NearbyPinsQueryParamsSchema,
    ReportPinRequestSchema,
+   type SearchPinsQuery,
    SearchPinsQueryParamsSchema,
    SoundPinApiSchema,
-   type NearbyPinsQuery,
-   type SearchPinsQuery,
    UpdatePinRequestSchema,
 } from "@sonory/shared-types"
 import { APIException } from "../middleware/error"
@@ -120,7 +120,9 @@ const nearbyPinsRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: ApiSuccessWithMetaResponseSchema(z.array(SoundPinApiSchema)),
+               schema: ApiSuccessWithMetaResponseSchema(
+                  z.array(SoundPinApiSchema),
+               ),
             },
          },
          description: "周辺ピン一覧",
@@ -195,7 +197,9 @@ const batchCreatePinsRoute = createRoute({
       200: {
          content: {
             "application/json": {
-               schema: ApiSuccessWithMetaResponseSchema(z.array(SoundPinApiSchema)),
+               schema: ApiSuccessWithMetaResponseSchema(
+                  z.array(SoundPinApiSchema),
+               ),
             },
          },
          description: "作成されたピン一覧",

--- a/apps/api/src/services/audio.service.ts
+++ b/apps/api/src/services/audio.service.ts
@@ -48,6 +48,7 @@ interface QueueMessage {
    audioId: string
    audioUrl: string
    retryCount?: number
+   rootMessageId?: number
    metadata?: Record<string, unknown>
 }
 
@@ -805,12 +806,13 @@ export class AudioService extends BaseService {
    ): Promise<void> {
       const messageId = queueMessage.msg_id
       const message = queueMessage.message
+      const jobId = message.rootMessageId ?? messageId
       const retryCount = message.retryCount || 0
 
       try {
          // 分析結果テーブルに処理中レコードを挿入
          await this.supabaseClient.from("analysis_results").upsert({
-            message_id: messageId,
+            message_id: jobId,
             audio_id: message.audioId,
             status: "processing",
             retry_count: retryCount,
@@ -837,7 +839,7 @@ export class AudioService extends BaseService {
                result: analysisResult,
                completed_at: new Date().toISOString(),
             })
-            .eq("message_id", messageId)
+            .eq("message_id", jobId)
 
          // キューからメッセージを削除
          await this.supabaseClient.rpc("queue_delete", {
@@ -868,7 +870,7 @@ export class AudioService extends BaseService {
 
          if (canRetry) {
             await this.supabaseClient.from("analysis_results").upsert({
-               message_id: messageId,
+               message_id: jobId,
                audio_id: message.audioId,
                status: "queued",
                retry_count: retryCount + 1,
@@ -882,6 +884,7 @@ export class AudioService extends BaseService {
             const retryMessage: QueueMessage = {
                ...message,
                retryCount: retryCount + 1,
+               rootMessageId: jobId,
             }
 
             await this.supabaseClient.rpc("queue_send", {
@@ -903,7 +906,7 @@ export class AudioService extends BaseService {
          } else {
             // 最大リトライ回数に達したら失敗として記録
             await this.supabaseClient.from("analysis_results").upsert({
-               message_id: messageId,
+               message_id: jobId,
                audio_id: message.audioId,
                status: "failed",
                error_message: errorMessage,
@@ -920,6 +923,7 @@ export class AudioService extends BaseService {
 
             this.log("error", "Analysis job failed after max retries", {
                messageId,
+               jobId,
                retryCount,
             })
          }

--- a/apps/api/src/services/audio.service.ts
+++ b/apps/api/src/services/audio.service.ts
@@ -867,6 +867,17 @@ export class AudioService extends BaseService {
          const canRetry = retryCount < this.maxRetries
 
          if (canRetry) {
+            await this.supabaseClient.from("analysis_results").upsert({
+               message_id: messageId,
+               audio_id: message.audioId,
+               status: "queued",
+               retry_count: retryCount + 1,
+               started_at: null,
+               completed_at: null,
+               error_message: null,
+               error_code: null,
+            })
+
             // メッセージを再キュー（リトライカウント増加）
             const retryMessage: QueueMessage = {
                ...message,

--- a/apps/api/src/services/pin.service.ts
+++ b/apps/api/src/services/pin.service.ts
@@ -1,6 +1,6 @@
 import {
-   ERROR_CODES,
    type CreatePinRequest,
+   ERROR_CODES,
    type LocationCoordinates,
    type NearbyPinsQuery,
    type SearchPinsQuery,

--- a/apps/api/src/services/pin.service.ts
+++ b/apps/api/src/services/pin.service.ts
@@ -1,9 +1,11 @@
 import {
    ERROR_CODES,
+   type CreatePinRequest,
    type LocationCoordinates,
    type NearbyPinsQuery,
    type SearchPinsQuery,
    type SoundPinAPI,
+   type UpdatePinRequest,
 } from "@sonory/shared-types"
 import type { Context } from "hono"
 import { APIException } from "../middleware/error"
@@ -390,7 +392,6 @@ export class PinService extends BaseService {
       url: string
       duration: number
       format: "webm" | "mp3" | "wav"
-      filePath?: string
    }): void {
       if (!audio.url || audio.url.trim() === "") {
          throw new APIException(
@@ -425,6 +426,7 @@ export class PinService extends BaseService {
     * @returns Database insert format
     */
    private toDatabaseInsert(request: CreatePinRequest): SoundPinInsert {
+      const userId = request.userId ?? null
       // PostGISのPOINT関数を使用してGeography型に変換
       const locationWKT = `POINT(${request.location.lng} ${request.location.lat})`
 
@@ -435,7 +437,7 @@ export class PinService extends BaseService {
 
          return {
             // 必須フィールド
-            user_id: null, // TODO: 認証実装後はコンテキストから取得
+            user_id: userId,
             location: locationWKT,
             audio_url: placeholderUrl,
             audio_duration: request.metadata?.duration ?? 10,
@@ -483,7 +485,7 @@ export class PinService extends BaseService {
 
       return {
          // 必須フィールド
-         user_id: null, // TODO: 認証実装後はコンテキストから取得
+         user_id: userId,
          location: locationWKT,
          audio_url: request.audio.url,
          audio_duration: request.audio.duration,
@@ -588,53 +590,5 @@ export class PinService extends BaseService {
               }
             : {}),
       }
-   }
-}
-
-// Type definitions for requests
-interface CreatePinRequest {
-   location: LocationCoordinates
-   audio?: {
-      url: string
-      duration: number
-      format: "webm" | "mp3" | "wav"
-      filePath?: string
-   }
-   audio_file_path?: string
-   metadata?: {
-      duration?: number
-      timeTag?: "朝" | "昼" | "夕" | "夜"
-      title?: string
-      deviceInfo?: string
-      weather?: {
-         temperature: number
-         condition?: string
-         windSpeed?: number
-         humidity?: number
-      }
-   }
-   weather?: {
-      temperature: number
-      condition?: string
-      windSpeed?: number
-      humidity?: number
-   }
-   timeTag?: "朝" | "昼" | "夕" | "夜"
-   title?: string
-   deviceInfo?: string
-}
-
-interface UpdatePinRequest {
-   title?: string
-   status?: "active" | "processing" | "deleted" | "reported"
-   aiAnalysis?: {
-      transcription: string
-      categories: {
-         emotion: string
-         topic: string
-         language: string
-         confidence: number
-      }
-      summary?: string
    }
 }

--- a/apps/api/src/services/pin.service.ts
+++ b/apps/api/src/services/pin.service.ts
@@ -426,7 +426,6 @@ export class PinService extends BaseService {
     * @returns Database insert format
     */
    private toDatabaseInsert(request: CreatePinRequest): SoundPinInsert {
-      const userId = request.userId ?? null
       // PostGISのPOINT関数を使用してGeography型に変換
       const locationWKT = `POINT(${request.location.lng} ${request.location.lat})`
 
@@ -437,7 +436,7 @@ export class PinService extends BaseService {
 
          return {
             // 必須フィールド
-            user_id: userId,
+            user_id: null,
             location: locationWKT,
             audio_url: placeholderUrl,
             audio_duration: request.metadata?.duration ?? 10,
@@ -485,7 +484,7 @@ export class PinService extends BaseService {
 
       return {
          // 必須フィールド
-         user_id: userId,
+         user_id: null,
          location: locationWKT,
          audio_url: request.audio.url,
          audio_duration: request.audio.duration,

--- a/apps/api/supabase/migrations/20260607000001_reset_auth_schema_to_pre_auth.sql
+++ b/apps/api/supabase/migrations/20260607000001_reset_auth_schema_to_pre_auth.sql
@@ -1,0 +1,383 @@
+-- =============================================================================
+-- Sonory: Better Auth 導入を取り消し、認証なし開発用スキーマへ戻す
+-- =============================================================================
+--
+-- 目的:
+-- - feature/better-auth-integration で追加された auth テーブル・FK・RLS を除去
+-- - sound_pins.user_id を UUID NULL 許可に戻す（apps/api/sql/002 と整合）
+-- - 開発データは破棄してクリーンな状態から再開
+--
+-- 前提:
+-- - 既存データの保持は不要（開発段階）
+-- - 認証は今後ゼロから作り直す
+--
+-- 適用後に必要な作業（アプリ側）:
+-- - apps/api の ANONYMOUS_USER_ID / ensureAnonymousUserExists を削除
+-- - ピン作成時 user_id: null で保存するよう戻す
+-- - Supabase Storage の sonory-audio バケット内ファイルは手動削除を推奨
+--
+-- 確認クエリ（適用後に実行）:
+--   SELECT column_name, data_type, is_nullable
+--   FROM information_schema.columns
+--   WHERE table_name = 'sound_pins' AND column_name = 'user_id';
+--   -- => uuid, YES
+--
+--   SELECT conname FROM pg_constraint
+--   WHERE conrelid = 'sound_pins'::regclass AND contype = 'f';
+--   -- => fk_sound_pins_user_id が無いこと
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. 開発データの削除
+-- -----------------------------------------------------------------------------
+DO $$
+BEGIN
+  IF to_regclass('public.analysis_results') IS NOT NULL THEN
+    TRUNCATE TABLE public.analysis_results;
+  END IF;
+END $$;
+
+TRUNCATE TABLE public.sound_pins;
+
+-- -----------------------------------------------------------------------------
+-- 2. sound_pins の RLS ポリシーをすべて削除
+--    user_id を参照するポリシーがあると ALTER TYPE が失敗するため、先に除去する
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+  pol RECORD;
+BEGIN
+  FOR pol IN
+    SELECT policyname
+    FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'sound_pins'
+  LOOP
+    EXECUTE format('DROP POLICY IF EXISTS %I ON public.sound_pins', pol.policyname);
+  END LOOP;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 3. sound_pins の auth 制約を解除し、user_id を UUID NULL に戻す
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.sound_pins
+  DROP CONSTRAINT IF EXISTS fk_sound_pins_user_id;
+
+ALTER TABLE public.sound_pins
+  ALTER COLUMN user_id DROP NOT NULL;
+
+-- TEXT 型の better-auth ID は UUID に変換できないため、NULL として戻す
+ALTER TABLE public.sound_pins
+  ALTER COLUMN user_id TYPE UUID
+  USING NULL;
+
+-- インデックスを元の部分インデックス定義に戻す
+DROP INDEX IF EXISTS public.idx_sound_pins_user_id;
+CREATE INDEX IF NOT EXISTS idx_sound_pins_user_id
+  ON public.sound_pins (user_id)
+  WHERE user_id IS NOT NULL;
+
+-- -----------------------------------------------------------------------------
+-- 4. Better Auth テーブルと関連オブジェクトを削除
+-- -----------------------------------------------------------------------------
+DROP TABLE IF EXISTS public.sessions CASCADE;
+DROP TABLE IF EXISTS public.accounts CASCADE;
+DROP TABLE IF EXISTS public.users CASCADE;
+
+-- -----------------------------------------------------------------------------
+-- 5. sound_pins の RLS ポリシーを初期状態へ戻す
+--    （apps/api/sql/003_sound_pins_rls_policies.sql 相当）
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.sound_pins ENABLE ROW LEVEL SECURITY;
+
+-- 初期ポリシーを再作成
+DROP POLICY IF EXISTS "Public pins are viewable by everyone" ON public.sound_pins;
+CREATE POLICY "Public pins are viewable by everyone"
+  ON public.sound_pins
+  FOR SELECT
+  USING (status = 'active');
+
+DROP POLICY IF EXISTS "Service role can insert pins" ON public.sound_pins;
+CREATE POLICY "Service role can insert pins"
+  ON public.sound_pins
+  FOR INSERT
+  TO service_role
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Service role can update pins" ON public.sound_pins;
+CREATE POLICY "Service role can update pins"
+  ON public.sound_pins
+  FOR UPDATE
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Service role can delete pins" ON public.sound_pins;
+CREATE POLICY "Service role can delete pins"
+  ON public.sound_pins
+  FOR DELETE
+  TO service_role
+  USING (true);
+
+-- -----------------------------------------------------------------------------
+-- 6. RPC 関数を UUID 前提の定義に戻す
+--    （apps/api/sql/008, 009 相当）
+-- -----------------------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS public.create_sound_pin;
+
+CREATE OR REPLACE FUNCTION public.create_sound_pin(
+  p_user_id UUID,
+  p_lat DOUBLE PRECISION,
+  p_lng DOUBLE PRECISION,
+  p_audio_url TEXT,
+  p_audio_duration REAL,
+  p_audio_format VARCHAR(10),
+  p_weather_temperature REAL DEFAULT NULL,
+  p_weather_condition VARCHAR(50) DEFAULT NULL,
+  p_weather_wind_speed REAL DEFAULT NULL,
+  p_weather_humidity REAL DEFAULT NULL,
+  p_time_tag VARCHAR(10) DEFAULT NULL,
+  p_title VARCHAR(200) DEFAULT NULL,
+  p_device_info TEXT DEFAULT NULL,
+  p_audio_file_path TEXT DEFAULT NULL
+)
+RETURNS TABLE (
+  id UUID,
+  user_id UUID,
+  location TEXT,
+  audio_url TEXT,
+  audio_file_path TEXT,
+  audio_duration REAL,
+  audio_format VARCHAR(10),
+  weather_temperature REAL,
+  weather_condition VARCHAR(50),
+  weather_wind_speed REAL,
+  weather_humidity REAL,
+  time_tag VARCHAR(10),
+  ai_analysis_result JSONB,
+  status VARCHAR(20),
+  title VARCHAR(200),
+  device_info TEXT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  deleted_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  new_pin_id UUID;
+BEGIN
+  INSERT INTO public.sound_pins (
+    user_id,
+    location,
+    audio_url,
+    audio_file_path,
+    audio_duration,
+    audio_format,
+    weather_temperature,
+    weather_condition,
+    weather_wind_speed,
+    weather_humidity,
+    time_tag,
+    title,
+    device_info,
+    status
+  ) VALUES (
+    p_user_id,
+    ST_SetSRID(ST_MakePoint(p_lng, p_lat), 4326)::geography,
+    p_audio_url,
+    p_audio_file_path,
+    p_audio_duration,
+    p_audio_format,
+    p_weather_temperature,
+    p_weather_condition,
+    p_weather_wind_speed,
+    p_weather_humidity,
+    p_time_tag,
+    p_title,
+    p_device_info,
+    'active'
+  )
+  RETURNING public.sound_pins.id INTO new_pin_id;
+
+  RETURN QUERY
+  SELECT
+    sp.id,
+    sp.user_id,
+    ST_AsText(sp.location::geometry) AS location,
+    sp.audio_url,
+    sp.audio_file_path,
+    sp.audio_duration,
+    sp.audio_format,
+    sp.weather_temperature,
+    sp.weather_condition,
+    sp.weather_wind_speed,
+    sp.weather_humidity,
+    sp.time_tag,
+    sp.ai_analysis_result,
+    sp.status,
+    sp.title,
+    sp.device_info,
+    sp.created_at,
+    sp.updated_at,
+    sp.deleted_at
+  FROM public.sound_pins sp
+  WHERE sp.id = new_pin_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.create_sound_pin TO authenticated;
+GRANT EXECUTE ON FUNCTION public.create_sound_pin TO service_role;
+
+DROP FUNCTION IF EXISTS public.find_pins_within_bounds;
+
+CREATE OR REPLACE FUNCTION public.find_pins_within_bounds(
+  north DOUBLE PRECISION,
+  south DOUBLE PRECISION,
+  east DOUBLE PRECISION,
+  west DOUBLE PRECISION,
+  max_results INTEGER DEFAULT 50,
+  categories TEXT[] DEFAULT NULL
+)
+RETURNS TABLE (
+  id UUID,
+  user_id UUID,
+  location TEXT,
+  audio_url TEXT,
+  audio_file_path TEXT,
+  audio_duration REAL,
+  audio_format VARCHAR(10),
+  weather_temperature REAL,
+  weather_condition VARCHAR(50),
+  weather_wind_speed REAL,
+  weather_humidity REAL,
+  time_tag VARCHAR(10),
+  ai_analysis_result JSONB,
+  status VARCHAR(20),
+  title VARCHAR(200),
+  device_info TEXT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  deleted_at TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    sp.id,
+    sp.user_id,
+    ST_AsText(sp.location::geometry) AS location,
+    sp.audio_url,
+    sp.audio_file_path,
+    sp.audio_duration,
+    sp.audio_format,
+    sp.weather_temperature,
+    sp.weather_condition,
+    sp.weather_wind_speed,
+    sp.weather_humidity,
+    sp.time_tag,
+    sp.ai_analysis_result,
+    sp.status,
+    sp.title,
+    sp.device_info,
+    sp.created_at,
+    sp.updated_at,
+    sp.deleted_at
+  FROM public.sound_pins sp
+  WHERE
+    sp.status = 'active'
+    AND sp.location && ST_MakeEnvelope(west, south, east, north, 4326)
+    AND ST_Within(sp.location::geometry, ST_MakeEnvelope(west, south, east, north, 4326))
+    AND (categories IS NULL OR (sp.ai_analysis_result->>'topic') = ANY(categories))
+  ORDER BY sp.created_at DESC
+  LIMIT max_results;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.find_pins_within_bounds TO authenticated;
+GRANT EXECUTE ON FUNCTION public.find_pins_within_bounds TO service_role;
+
+DROP FUNCTION IF EXISTS public.find_nearby_pins;
+
+CREATE OR REPLACE FUNCTION public.find_nearby_pins(
+  lat DOUBLE PRECISION,
+  lng DOUBLE PRECISION,
+  radius_meters INTEGER,
+  max_results INTEGER DEFAULT 50
+)
+RETURNS TABLE (
+  id UUID,
+  user_id UUID,
+  location TEXT,
+  audio_url TEXT,
+  audio_file_path TEXT,
+  audio_duration REAL,
+  audio_format VARCHAR(10),
+  weather_temperature REAL,
+  weather_condition VARCHAR(50),
+  weather_wind_speed REAL,
+  weather_humidity REAL,
+  time_tag VARCHAR(10),
+  ai_analysis_result JSONB,
+  status VARCHAR(20),
+  title VARCHAR(200),
+  device_info TEXT,
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  deleted_at TIMESTAMPTZ,
+  distance_meters DOUBLE PRECISION
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    sp.id,
+    sp.user_id,
+    ST_AsText(sp.location::geometry) AS location,
+    sp.audio_url,
+    sp.audio_file_path,
+    sp.audio_duration,
+    sp.audio_format,
+    sp.weather_temperature,
+    sp.weather_condition,
+    sp.weather_wind_speed,
+    sp.weather_humidity,
+    sp.time_tag,
+    sp.ai_analysis_result,
+    sp.status,
+    sp.title,
+    sp.device_info,
+    sp.created_at,
+    sp.updated_at,
+    sp.deleted_at,
+    ST_Distance(
+      sp.location::geography,
+      ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography
+    ) AS distance_meters
+  FROM public.sound_pins sp
+  WHERE
+    sp.status = 'active'
+    AND ST_DWithin(
+      sp.location::geography,
+      ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography,
+      radius_meters
+    )
+  ORDER BY distance_meters ASC
+  LIMIT max_results;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.find_nearby_pins TO authenticated;
+GRANT EXECUTE ON FUNCTION public.find_nearby_pins TO service_role;
+
+COMMIT;

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -14,7 +14,7 @@ crons = ["* * * * *"]
 [env.production.vars]
 ENVIRONMENT = "production"
 PYTHON_AUDIO_ANALYZER_URL = "https://python-audio-analyzer.onrender.com"
-PYTHON_AUDIO_ANALYZER_TIMEOUT = "30000"
+PYTHON_AUDIO_ANALYZER_TIMEOUT = "120000"
 
 # 本番環境の機密情報は以下のコマンドで設定:
 # wrangler secret put SUPABASE_URL --env production
@@ -31,7 +31,7 @@ crons = ["* * * * *"]
 [env.staging.vars]
 ENVIRONMENT = "staging"
 PYTHON_AUDIO_ANALYZER_URL = "https://python-audio-analyzer.onrender.com"
-PYTHON_AUDIO_ANALYZER_TIMEOUT = "30000"
+PYTHON_AUDIO_ANALYZER_TIMEOUT = "120000"
 
 # ステージング環境の機密情報は以下のコマンドで設定:
 # wrangler secret put SUPABASE_URL --env staging
@@ -45,7 +45,7 @@ name = "sonory-api-development"
 [env.development.vars]
 ENVIRONMENT = "development"
 PYTHON_AUDIO_ANALYZER_URL = "http://localhost:8000"
-PYTHON_AUDIO_ANALYZER_TIMEOUT = "30000"
+PYTHON_AUDIO_ANALYZER_TIMEOUT = "120000"
 # 開発環境のSupabase設定は.dev.varsファイルで管理
 
 # KVネームスペース（Phase 4以降で使用予定）

--- a/apps/web/src/components/organisms/MapComponent/utils/pinConverters.ts
+++ b/apps/web/src/components/organisms/MapComponent/utils/pinConverters.ts
@@ -2,15 +2,30 @@
  * ピン変換ユーティリティ
  */
 
-import type { SoundPinAPI } from "@sonory/shared-types"
+import type { NearbyPin, WeatherData } from "@sonory/shared-types"
 import type { SoundPin } from "@/store/useSoundPinStore"
+
+function normalizeWeather(apiPin: NearbyPin): WeatherData | undefined {
+   const weather = apiPin.weather
+
+   if (!weather) {
+      return undefined
+   }
+
+   return {
+      temperature: weather.temperature,
+      ...(weather.condition != null ? { condition: weather.condition } : {}),
+      ...(weather.windSpeed != null ? { windSpeed: weather.windSpeed } : {}),
+      ...(weather.humidity != null ? { humidity: weather.humidity } : {}),
+   }
+}
 
 /**
  * APIピンをローカルピン形式に変換
  * @param apiPin - APIピン
  * @returns ローカルピン
  */
-export const convertApiPinToLocal = (apiPin: SoundPinAPI): SoundPin => {
+export const convertApiPinToLocal = (apiPin: NearbyPin): SoundPin => {
    // デバッグ: APIピンの変換処理をログ出力
    if (process.env.NODE_ENV === "development") {
       console.log("🔄 Converting API pin to local format:", {
@@ -80,13 +95,6 @@ export const convertApiPinToLocal = (apiPin: SoundPinAPI): SoundPin => {
       isPersisted: true,
       timeTag: (apiPin.timeTag as "朝" | "昼" | "夕" | "夜") || undefined,
       environment,
-      weather: apiPin.weather
-         ? {
-              temperature: apiPin.weather.temperature,
-              condition: apiPin.weather.condition || "unknown",
-              windSpeed: apiPin.weather.windSpeed,
-              humidity: apiPin.weather.humidity,
-           }
-         : undefined,
+      weather: normalizeWeather(apiPin),
    }
 }

--- a/apps/web/src/domain/pin-converter.ts
+++ b/apps/web/src/domain/pin-converter.ts
@@ -4,9 +4,23 @@
  * DB/APIレスポンスとフロントエンドのSoundPin間の変換を行う
  */
 
+import type { WeatherData } from "@sonory/shared-types"
 import type { InferenceResult } from "../store/types"
 import type { SoundPin } from "../store/useSoundPinStore"
 import type { DbPin, PinApiResponse } from "./pin-types"
+
+function normalizeWeather(weather: DbPin["weather"]): WeatherData | undefined {
+   if (!weather) {
+      return undefined
+   }
+
+   return {
+      temperature: weather.temperature,
+      ...(weather.condition != null ? { condition: weather.condition } : {}),
+      ...(weather.windSpeed != null ? { windSpeed: weather.windSpeed } : {}),
+      ...(weather.humidity != null ? { humidity: weather.humidity } : {}),
+   }
+}
 
 /**
  * APIレスポンスをSoundPinに変換
@@ -39,7 +53,7 @@ export function convertApiResponseToPin(
       isPersisted: true,
       timeTag: result.data.timeTag,
       environment: primaryResult?.label || "unknown",
-      weather: result.data.weather,
+      weather: normalizeWeather(result.data.weather),
    }
 }
 
@@ -74,9 +88,7 @@ export function buildClassificationResults(pin: DbPin): InferenceResult[] {
 /**
  * DBピンをSoundPinに変換
  */
-export function convertDbPinToSoundPin(dbPin: unknown): SoundPin {
-   const pin = dbPin as DbPin
-
+export function convertDbPinToSoundPin(pin: DbPin): SoundPin {
    const classificationResults = buildClassificationResults(pin)
    const primaryLabel =
       pin.title || pin.aiAnalysis?.categories?.topic || "音声ピン"
@@ -98,7 +110,7 @@ export function convertDbPinToSoundPin(dbPin: unknown): SoundPin {
       primaryLabel,
       primaryConfidence: pin.aiAnalysis?.categories?.confidence ?? 0.8,
       isPersisted: true,
-      weather: pin.weather,
+      weather: normalizeWeather(pin.weather),
       timeTag: pin.timeTag,
       environment,
    }

--- a/apps/web/src/domain/pin-types.ts
+++ b/apps/web/src/domain/pin-types.ts
@@ -1,51 +1,15 @@
-import type { WeatherData } from "@sonory/shared-types"
+import type {
+   CreatePinResponse,
+   HonoSoundPin,
+   UploadPinResponse,
+} from "@sonory/shared-types"
 
 /**
  * ピン作成APIレスポンスの型
  */
-export interface PinApiResponse {
-   success: boolean
-   data?: {
-      id: string
-      audio_url: string
-      location: {
-         lat: number
-         lng: number
-      }
-      audio: {
-         url: string
-      }
-      createdAt: string
-      timeTag?: "朝" | "昼" | "夕" | "夜"
-      weather?: WeatherData
-   }
-   error?: string
-}
+export type PinApiResponse = CreatePinResponse | UploadPinResponse
 
 /**
  * DBから取得したピンの型
  */
-export interface DbPin {
-   id: string
-   location: { lat: number; lng: number }
-   audio: { url: string; duration: number; format: string }
-   title?: string
-   timeTag?: "朝" | "昼" | "夕" | "夜"
-   weather?: WeatherData
-   aiAnalysis?: {
-      transcription: string
-      categories: {
-         confidence: number
-         topic: string
-         emotion: string
-         language: string
-      }
-      summary?: string
-   }
-   status: "active" | "processing" | "deleted" | "reported"
-   createdAt: string
-   updatedAt: string
-   metadata?: {
-      deviceInfo: string
-   }
-}
+export type DbPin = HonoSoundPin

--- a/apps/web/src/hooks/useNearbyPins.ts
+++ b/apps/web/src/hooks/useNearbyPins.ts
@@ -1,6 +1,10 @@
 "use client"
 
-import type { MapBounds, SoundPinAPI } from "@sonory/shared-types"
+import type {
+   MapBounds,
+   NearbyPin,
+   NearbyPinsResponse,
+} from "@sonory/shared-types"
 import {
    keepPreviousData,
    useQuery,
@@ -15,7 +19,7 @@ interface UseNearbyPinsOptions {
 }
 
 interface UseNearbyPinsResult {
-   pins: SoundPinAPI[]
+   pins: NearbyPin[]
    isLoading: boolean
    error: Error | null
    refetch: () => void
@@ -68,7 +72,7 @@ const generateAdjacentBounds = (bounds: MapBounds): MapBounds[] => {
 }
 
 // Request deduplication map
-const pendingRequests = new Map<string, Promise<SoundPinAPI[]>>()
+const pendingRequests = new Map<string, Promise<NearbyPin[]>>()
 
 /**
  * Fetches pins from API with ultra-optimized settings and request deduplication
@@ -77,7 +81,7 @@ const fetchPinsFromAPI = async (
    bounds: MapBounds,
    limit = 50,
    categories?: string[],
-): Promise<SoundPinAPI[]> => {
+): Promise<NearbyPin[]> => {
    const params = new URLSearchParams({
       north: bounds.north.toString(),
       south: bounds.south.toString(),
@@ -121,8 +125,13 @@ const fetchPinsFromAPI = async (
             throw new Error(`Failed to fetch pins: ${response.statusText}`)
          }
 
-         const data = await response.json()
-         return data.data || []
+         const data = (await response.json()) as NearbyPinsResponse
+
+         if (!data.success || !data.data) {
+            throw new Error("ピン取得結果が不正です")
+         }
+
+         return data.data
       } finally {
          clearTimeout(timeoutId)
          // Remove from pending requests

--- a/apps/web/src/services/analysis.ts
+++ b/apps/web/src/services/analysis.ts
@@ -5,10 +5,14 @@
  */
 
 import type {
-   AudioData,
+   AnalysisStatusData,
+   AnalysisStatusResponse,
    InferenceResult,
    PythonAnalysisResult,
-} from "../store/types"
+   SubmitAnalysisJobResponse,
+   UploadAudioResponse,
+} from "@sonory/shared-types"
+import type { AudioData } from "../store/types"
 import { type ApiClient, defaultApiClient } from "./api-client"
 
 interface APIClassification {
@@ -55,38 +59,37 @@ export function generateClassificationResults(): InferenceResult[] {
    )
 }
 
-interface UploadResponse {
-   success: boolean
-   data?: { audioUrl?: string }
-}
-
 /**
  * 音声ファイルをSupabase Storageにアップロード
  *
  * @param audioData - 音声データ
  * @param client - APIクライアント（テスト時に差し替え可能）
  */
+export interface UploadedAudioRef {
+   audioUrl: string
+   audioId: string
+}
+
 export async function uploadAudioToStorage(
    audioData: AudioData,
    client: ApiClient = defaultApiClient,
-): Promise<string> {
+): Promise<UploadedAudioRef> {
    const formData = new FormData()
    formData.append("audio", audioData.blob, `audio-${audioData.id}.webm`)
 
-   const result = await client.postFormData<UploadResponse>(
+   const result = await client.postFormData<UploadAudioResponse>(
       "/api/audio/upload",
       formData,
    )
 
-   if (!result.success || !result.data?.audioUrl) {
+   if (!result.success || !result.data?.audioUrl || !result.data.audioId) {
       throw new Error("アップロード結果が不正です")
    }
-   return result.data.audioUrl
-}
 
-interface AnalyzeResponse {
-   success: boolean
-   data?: { jobId?: string }
+   return {
+      audioUrl: result.data.audioUrl,
+      audioId: result.data.audioId,
+   }
 }
 
 /**
@@ -101,7 +104,7 @@ export async function submitAnalysisJob(
    audioUrl: string,
    client: ApiClient = defaultApiClient,
 ): Promise<string> {
-   const result = await client.post<AnalyzeResponse>(
+   const result = await client.post<SubmitAnalysisJobResponse>(
       `/api/audio/${audioId}/analyze`,
       { audioUrl, topK: 5 },
    )
@@ -133,15 +136,6 @@ export function convertAnalysisResult(
    return classifications
 }
 
-interface JobStatusResponse {
-   success: boolean
-   data?: {
-      status: string
-      result?: PythonAnalysisResult
-      error?: { message?: string }
-   }
-}
-
 /**
  * ジョブステータスを取得
  */
@@ -150,11 +144,11 @@ async function fetchJobStatus(
    jobId: string,
    client: ApiClient,
 ): Promise<{
-   status: string
-   result?: PythonAnalysisResult
-   error?: { message?: string }
+   status: AnalysisStatusData["status"]
+   result?: AnalysisStatusData["result"]
+   error?: AnalysisStatusData["error"]
 }> {
-   const result = await client.get<JobStatusResponse>(
+   const result = await client.get<AnalysisStatusResponse>(
       `/api/audio/${audioId}/analysis/${jobId}/status`,
    )
 
@@ -177,11 +171,13 @@ export async function pollJobStatus(
    jobId: string,
    client: ApiClient = defaultApiClient,
 ): Promise<InferenceResult[]> {
-   const maxAttempts = 60
+   const maxAttempts = 120
    const pollInterval = 1000
 
    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      await new Promise((resolve) => setTimeout(resolve, pollInterval))
+      if (attempt > 1) {
+         await new Promise((resolve) => setTimeout(resolve, pollInterval))
+      }
 
       const { status, result, error } = await fetchJobStatus(
          audioId,

--- a/apps/web/src/services/api-client.ts
+++ b/apps/web/src/services/api-client.ts
@@ -29,11 +29,26 @@ class ApiError extends Error {
 
 async function handleResponse<T>(response: Response): Promise<T> {
    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({}))
+      const rawBody = await response.text()
+      let errorData: unknown = {}
+
+      if (rawBody) {
+         try {
+            errorData = JSON.parse(rawBody) as unknown
+         } catch {
+            throw new ApiError(rawBody, response.status)
+         }
+      }
+
+      const parsed = errorData as {
+         message?: string
+         error?: { message?: string }
+      }
       const message =
-         (errorData as { message?: string }).message ??
-         (errorData as { error?: { message?: string } }).error?.message ??
+         parsed.message ??
+         parsed.error?.message ??
          `API error: ${response.status}`
+
       throw new ApiError(message, response.status)
    }
    return response.json() as Promise<T>

--- a/apps/web/src/services/pin-api.ts
+++ b/apps/web/src/services/pin-api.ts
@@ -4,15 +4,25 @@
  * バックエンドAPIとの通信ロジックを集約
  */
 
-import type { MapBounds, WeatherData } from "@sonory/shared-types"
+import type {
+   CreatePinRequestBody,
+   DeletePinResponse,
+   HonoFormRequestBody,
+   MapBounds,
+   NearbyPinsResponse,
+   WeatherData,
+} from "@sonory/shared-types"
 import type { PinApiResponse } from "../domain/pin-types"
 import { type ApiClient, defaultApiClient } from "./api-client"
+
+type PinTimeTag = NonNullable<CreatePinRequestBody["timeTag"]>
+type PinMetadata = NonNullable<CreatePinRequestBody["metadata"]>
 
 interface PinCreateParams {
    audioFilePath: string
    location: { lat: number; lng: number; accuracy?: number }
    duration: number
-   timeTag: string
+   timeTag: PinTimeTag
    title: string
    deviceInfo: string
    weather?: WeatherData
@@ -22,7 +32,7 @@ interface PinUploadParams {
    audioBlob: Blob
    location: { lat: number; lng: number; accuracy?: number }
    duration: number
-   timeTag: string
+   timeTag: PinTimeTag
    title: string
    deviceInfo: string
    weather?: WeatherData
@@ -38,7 +48,7 @@ export async function createPinFromStorageUrl(
    params: PinCreateParams,
    client: ApiClient = defaultApiClient,
 ): Promise<PinApiResponse> {
-   return client.post<PinApiResponse>("/api/pins", {
+   const body: CreatePinRequestBody = {
       audio_file_path: params.audioFilePath,
       location: params.location,
       metadata: {
@@ -48,7 +58,9 @@ export async function createPinFromStorageUrl(
          deviceInfo: params.deviceInfo,
          ...(params.weather ? { weather: params.weather } : {}),
       },
-   })
+   }
+
+   return client.post<PinApiResponse>("/api/pins", body)
 }
 
 /**
@@ -61,19 +73,23 @@ export async function uploadPinWithAudio(
    params: PinUploadParams,
    client: ApiClient = defaultApiClient,
 ): Promise<PinApiResponse> {
+   type UploadPinForm = HonoFormRequestBody<"/api/pins/upload", "post">
+   const metadata: PinMetadata = {
+      duration: params.duration,
+      timeTag: params.timeTag,
+      title: params.title,
+      deviceInfo: params.deviceInfo,
+      ...(params.weather ? { weather: params.weather } : {}),
+   }
+   const formShape: UploadPinForm = {
+      audio: params.audioBlob,
+      location: JSON.stringify(params.location),
+      metadata: JSON.stringify(metadata),
+   }
    const formData = new FormData()
-   formData.append("audio", params.audioBlob, "audio.webm")
-   formData.append("location", JSON.stringify(params.location))
-   formData.append(
-      "metadata",
-      JSON.stringify({
-         duration: params.duration,
-         timeTag: params.timeTag,
-         title: params.title,
-         deviceInfo: params.deviceInfo,
-         ...(params.weather ? { weather: params.weather } : {}),
-      }),
-   )
+   formData.append("audio", formShape.audio as Blob, "audio.webm")
+   formData.append("location", formShape.location)
+   formData.append("metadata", formShape.metadata ?? "{}")
 
    return client.postFormData<PinApiResponse>("/api/pins/upload", formData)
 }
@@ -87,7 +103,7 @@ export async function uploadPinWithAudio(
 export async function fetchNearbyPins(
    bounds: MapBounds,
    client: ApiClient = defaultApiClient,
-): Promise<{ success: boolean; data?: unknown[] }> {
+): Promise<NearbyPinsResponse> {
    const params = new URLSearchParams({
       north: bounds.north.toString(),
       south: bounds.south.toString(),
@@ -96,9 +112,7 @@ export async function fetchNearbyPins(
       limit: "50",
    })
 
-   return client.get<{ success: boolean; data?: unknown[] }>(
-      `/api/pins/nearby?${params}`,
-   )
+   return client.get<NearbyPinsResponse>(`/api/pins/nearby?${params}`)
 }
 
 /**
@@ -111,9 +125,7 @@ export async function deletePin(
    pinId: string,
    client: ApiClient = defaultApiClient,
 ): Promise<void> {
-   const result = await client.delete<{ success: boolean }>(
-      `/api/pins/${pinId}`,
-   )
+   const result = await client.delete<DeletePinResponse>(`/api/pins/${pinId}`)
 
    if (!result.success) {
       throw new Error("ピン削除結果が不正です")

--- a/apps/web/src/store/useInferenceStore.ts
+++ b/apps/web/src/store/useInferenceStore.ts
@@ -47,16 +47,21 @@ export const useInferenceStore = create<InferenceState>((set, _get) => ({
 
          let results: InferenceResult[]
          let isUsingFallback = false
+         let resolvedAudioId = audioData.id
 
          try {
             const recorderState = useRecorderStore.getState()
             let audioUrl = recorderState.uploadedAudioUrl
+            let audioId = recorderState.uploadedAudioId
 
-            if (!audioUrl) {
-               audioUrl = await uploadAudioToStorage(audioData)
+            if (!audioUrl || !audioId) {
+               const uploaded = await uploadAudioToStorage(audioData)
+               audioUrl = uploaded.audioUrl
+               audioId = uploaded.audioId
             }
 
-            results = await callBackendAnalysis(audioData.id, audioUrl)
+            resolvedAudioId = audioId
+            results = await callBackendAnalysis(audioId, audioUrl)
 
             const pythonResult: PythonAnalysisResult = {
                classifications: results.map((r) => ({
@@ -68,6 +73,7 @@ export const useInferenceStore = create<InferenceState>((set, _get) => ({
             set({
                analysisStatus: "success",
                backendAnalysisResult: pythonResult,
+               lastAnalyzedAudioId: resolvedAudioId,
             })
          } catch (_backendError) {
             isUsingFallback = true

--- a/apps/web/src/store/useRecorderStore.ts
+++ b/apps/web/src/store/useRecorderStore.ts
@@ -43,10 +43,9 @@ function createUploadFormData(
 /**
  * アップロードレスポンスを検証する
  */
-function validateUploadResponse(result: unknown): Pick<
-   UploadAudioResponse["data"],
-   "audioUrl" | "audioId"
-> {
+function validateUploadResponse(
+   result: unknown,
+): Pick<UploadAudioResponse["data"], "audioUrl" | "audioId"> {
    if (
       typeof result !== "object" ||
       result === null ||

--- a/apps/web/src/store/useRecorderStore.ts
+++ b/apps/web/src/store/useRecorderStore.ts
@@ -1,3 +1,4 @@
+import type { UploadAudioResponse } from "@sonory/shared-types"
 import { create } from "zustand"
 import type { AudioData, RecorderState } from "./types"
 
@@ -42,10 +43,10 @@ function createUploadFormData(
 /**
  * アップロードレスポンスを検証する
  */
-function validateUploadResponse(result: unknown): {
-   audioUrl: string
-   audioId: string
-} {
+function validateUploadResponse(result: unknown): Pick<
+   UploadAudioResponse["data"],
+   "audioUrl" | "audioId"
+> {
    if (
       typeof result !== "object" ||
       result === null ||

--- a/apps/web/src/store/useSoundPinStore.ts
+++ b/apps/web/src/store/useSoundPinStore.ts
@@ -1,13 +1,9 @@
 import type { MapBounds, WeatherData } from "@sonory/shared-types"
 import { create } from "zustand"
 import { calculateDistanceKm, generateTimeTag } from "../domain/geo"
-import {
-   convertApiResponseToPin,
-   convertDbPinToSoundPin,
-} from "../domain/pin-converter"
+import { convertApiResponseToPin } from "../domain/pin-converter"
 import {
    createPinFromStorageUrl,
-   fetchNearbyPins,
    uploadPinWithAudio,
 } from "../services/pin-api"
 import { fetchWeatherData } from "../services/weather"
@@ -58,8 +54,6 @@ export type SoundPinState = {
    pinCreationStatus: PinCreationStatus
    pinCreationError: string | null
    lastCreatedPinId: string | null
-   isLoadingNearbyPins: boolean
-   nearbyPinsError: string | null
    addPin: (
       pin: Omit<
          SoundPin,
@@ -83,7 +77,6 @@ export type SoundPinState = {
    setPinCreationStatus: (status: PinCreationStatus) => void
    setPinCreationError: (error: string | null) => void
    mergeLocalAndPersistedPins: () => SoundPin[]
-   loadNearbyPins: (bounds: MapBounds) => Promise<SoundPin[]>
    clearPinCreationState: () => void
 }
 
@@ -133,8 +126,6 @@ export const useSoundPinStore = create<SoundPinState>((set, get) => ({
    pinCreationStatus: "idle",
    pinCreationError: null,
    lastCreatedPinId: null,
-   isLoadingNearbyPins: false,
-   nearbyPinsError: null,
 
    addPin: (pin): void => {
       const primaryResult = pin.classificationResults[0]
@@ -300,37 +291,6 @@ export const useSoundPinStore = create<SoundPinState>((set, get) => ({
          if (!a.isPersisted && b.isPersisted) return 1
          return b.recordedAt.getTime() - a.recordedAt.getTime()
       })
-   },
-
-   loadNearbyPins: async (bounds: MapBounds): Promise<SoundPin[]> => {
-      try {
-         set({ isLoadingNearbyPins: true, nearbyPinsError: null })
-
-         const result = await fetchNearbyPins(bounds)
-
-         if (!result.success || !result.data) {
-            throw new Error("ピン取得結果が不正です")
-         }
-
-         const loadedPins: SoundPin[] = (result.data || []).map(
-            (dbPin: unknown) => convertDbPinToSoundPin(dbPin),
-         )
-
-         set({
-            persistedPins: loadedPins,
-            isLoadingNearbyPins: false,
-            nearbyPinsError: null,
-         })
-
-         return loadedPins
-      } catch (error) {
-         const errorMessage =
-            error instanceof Error ? error.message : "ピン取得に失敗しました"
-
-         set({ isLoadingNearbyPins: false, nearbyPinsError: errorMessage })
-
-         throw error
-      }
    },
 
    clearPinCreationState: (): void => {

--- a/packages/python-types/src/generate-python-types.ts
+++ b/packages/python-types/src/generate-python-types.ts
@@ -46,6 +46,11 @@ interface GenerateResult {
    outputFile: string
 }
 
+const ZOD_SCHEMA_NAME_BY_TYPE: Partial<Record<string, string>> = {
+   AIAnalysis: "AiAnalysis",
+   SoundPinAPI: "SoundPinApi",
+}
+
 function convertType(tsType: string): string {
    const normalizedType = tsType.trim().replace(/[,;]$/, "")
 
@@ -338,6 +343,14 @@ function resolveTypeDefinition(
       const fromZod = parseZodObjectSchema(content, typeName)
       if (fromZod) {
          return fromZod
+      }
+
+      const schemaTypeName = ZOD_SCHEMA_NAME_BY_TYPE[typeName]
+      if (schemaTypeName) {
+         const fromMappedSchema = parseZodObjectSchema(content, schemaTypeName)
+         if (fromMappedSchema) {
+            return { ...fromMappedSchema, name: typeName }
+         }
       }
    }
 

--- a/packages/shared-types/openapi/hono-api.json
+++ b/packages/shared-types/openapi/hono-api.json
@@ -1660,6 +1660,9 @@
                                        "mp3",
                                        "wav"
                                     ]
+                                 },
+                                 "filePath": {
+                                    "type": "string"
                                  }
                               },
                               "required": [
@@ -1798,10 +1801,14 @@
                                        "type": "object",
                                        "properties": {
                                           "lat": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -90,
+                                             "maximum": 90
                                           },
                                           "lng": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -180,
+                                             "maximum": 180
                                           },
                                           "accuracy": {
                                              "type": "number",
@@ -2166,10 +2173,14 @@
                                        "type": "object",
                                        "properties": {
                                           "lat": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -90,
+                                             "maximum": 90
                                           },
                                           "lng": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -180,
+                                             "maximum": 180
                                           },
                                           "accuracy": {
                                              "type": "number",
@@ -2580,10 +2591,14 @@
                                           "type": "object",
                                           "properties": {
                                              "lat": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -90,
+                                                "maximum": 90
                                              },
                                              "lng": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -180,
+                                                "maximum": 180
                                              },
                                              "accuracy": {
                                                 "type": "number",
@@ -3028,10 +3043,14 @@
                                           "type": "object",
                                           "properties": {
                                              "lat": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -90,
+                                                "maximum": 90
                                              },
                                              "lng": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -180,
+                                                "maximum": 180
                                              },
                                              "accuracy": {
                                                 "type": "number",
@@ -3385,10 +3404,14 @@
                                           "type": "object",
                                           "properties": {
                                              "lat": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -90,
+                                                "maximum": 90
                                              },
                                              "lng": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -180,
+                                                "maximum": 180
                                              },
                                              "accuracy": {
                                                 "type": "number",
@@ -3759,6 +3782,9 @@
                                           "mp3",
                                           "wav"
                                        ]
+                                    },
+                                    "filePath": {
+                                       "type": "string"
                                     }
                                  },
                                  "required": [
@@ -3900,10 +3926,14 @@
                                           "type": "object",
                                           "properties": {
                                              "lat": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -90,
+                                                "maximum": 90
                                              },
                                              "lng": {
-                                                "type": "number"
+                                                "type": "number",
+                                                "minimum": -180,
+                                                "maximum": 180
                                              },
                                              "accuracy": {
                                                 "type": "number",
@@ -4261,10 +4291,14 @@
                                        "type": "object",
                                        "properties": {
                                           "lat": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -90,
+                                             "maximum": 90
                                           },
                                           "lng": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -180,
+                                             "maximum": 180
                                           },
                                           "accuracy": {
                                              "type": "number",
@@ -4678,10 +4712,14 @@
                                        "type": "object",
                                        "properties": {
                                           "lat": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -90,
+                                             "maximum": 90
                                           },
                                           "lng": {
-                                             "type": "number"
+                                             "type": "number",
+                                             "minimum": -180,
+                                             "maximum": 180
                                           },
                                           "accuracy": {
                                              "type": "number",

--- a/packages/shared-types/openapi/hono-api.json
+++ b/packages/shared-types/openapi/hono-api.json
@@ -1613,10 +1613,6 @@
                      "schema": {
                         "type": "object",
                         "properties": {
-                           "userId": {
-                              "type": "string",
-                              "format": "uuid"
-                           },
                            "location": {
                               "type": "object",
                               "properties": {
@@ -3735,10 +3731,6 @@
                         "items": {
                            "type": "object",
                            "properties": {
-                              "userId": {
-                                 "type": "string",
-                                 "format": "uuid"
-                              },
                               "location": {
                                  "type": "object",
                                  "properties": {

--- a/packages/shared-types/src/api-contract.ts
+++ b/packages/shared-types/src/api-contract.ts
@@ -1,0 +1,213 @@
+import { z } from "zod"
+import { AudioFormatSchema, PythonAnalysisResultSchema } from "./audio.js"
+import { LocationCoordinatesSchema, MapBoundsSchema, TimeTagSchema } from "./location.js"
+
+export const ApiWeatherDataSchema = z.object({
+   temperature: z.number(),
+   condition: z.string().optional().nullable(),
+   windSpeed: z.number().optional().nullable(),
+   humidity: z.number().min(0).max(100).optional().nullable(),
+})
+
+export const AiAnalysisSchema = z.object({
+   transcription: z.string(),
+   categories: z.object({
+      emotion: z.string(),
+      topic: z.string(),
+      language: z.string(),
+      confidence: z.number().min(0).max(1),
+   }),
+   summary: z.string().optional(),
+})
+
+export const SoundPinAudioSchema = z.object({
+   url: z.string(),
+   duration: z.number(),
+   format: AudioFormatSchema,
+})
+
+export const ApiErrorSchema = z.object({
+   code: z.string(),
+   message: z.string(),
+   details: z.unknown().optional(),
+   timestamp: z.string(),
+   requestId: z.string(),
+})
+
+export const ApiErrorResponseSchema = z.object({
+   success: z.literal(false),
+   error: ApiErrorSchema,
+})
+
+export const ApiSuccessResponseSchema = <T extends z.ZodType>(data: T) =>
+   z.object({
+      success: z.literal(true),
+      data,
+   })
+
+export const ApiSuccessWithMetaResponseSchema = <T extends z.ZodType>(
+   data: T,
+) =>
+   z.object({
+      success: z.literal(true),
+      data,
+      meta: z.record(z.string(), z.unknown()).optional(),
+   })
+
+export const SoundPinApiSchema = z.object({
+   id: z.string(),
+   userId: z.string().optional(),
+   location: LocationCoordinatesSchema,
+   audio: SoundPinAudioSchema,
+   weather: ApiWeatherDataSchema.optional(),
+   timeTag: TimeTagSchema.optional(),
+   aiAnalysis: AiAnalysisSchema.optional(),
+   status: z.enum(["active", "processing", "deleted", "reported"]),
+   title: z.string().optional(),
+   metadata: z
+      .object({
+         deviceInfo: z.string().optional(),
+      })
+      .optional(),
+   createdAt: z.string(),
+   updatedAt: z.string(),
+})
+
+export const CreatePinRequestSchema = z.object({
+   userId: z.string().uuid().optional(),
+   location: LocationCoordinatesSchema,
+   audio: z
+      .object({
+         url: z.string().url(),
+         duration: z.number().min(9.9).max(600),
+         format: z.enum(["webm", "mp3", "wav"]),
+         filePath: z.string().optional(),
+      })
+      .optional(),
+   audio_file_path: z.string().optional(),
+   metadata: z
+      .object({
+         duration: z.number().positive().optional(),
+         timeTag: TimeTagSchema.optional(),
+         title: z.string().max(200).optional(),
+         deviceInfo: z.string().optional(),
+         weather: ApiWeatherDataSchema.optional(),
+      })
+      .optional(),
+   weather: ApiWeatherDataSchema.optional(),
+   timeTag: TimeTagSchema.optional(),
+   title: z.string().max(200).optional(),
+   deviceInfo: z.string().optional(),
+})
+
+export const UpdatePinRequestSchema = z.object({
+   title: z.string().max(200).optional(),
+   status: z.enum(["active", "processing", "deleted", "reported"]).optional(),
+   aiAnalysis: AiAnalysisSchema.optional(),
+})
+
+export const NearbyPinsQueryParamsSchema = z.object({
+   north: z.coerce.number().min(-90).max(90),
+   south: z.coerce.number().min(-90).max(90),
+   east: z.coerce.number().min(-180).max(180),
+   west: z.coerce.number().min(-180).max(180),
+   limit: z.coerce.number().positive().max(100).optional(),
+   categories: z.array(z.string()).optional(),
+})
+
+export const SearchPinsQueryParamsSchema = z.object({
+   lat: z.coerce.number().min(-90).max(90).optional(),
+   lng: z.coerce.number().min(-180).max(180).optional(),
+   radius: z.coerce.number().positive().optional(),
+   startTime: z.string().datetime().optional(),
+   endTime: z.string().datetime().optional(),
+   categories: z.array(z.string()).optional(),
+   weather: z.array(z.string()).optional(),
+   limit: z.coerce.number().positive().max(100).optional(),
+   offset: z.coerce.number().nonnegative().optional(),
+})
+
+export const NearbyPinsQuerySchema = z.object({
+   bounds: MapBoundsSchema,
+   limit: z.number().positive().max(100).default(50),
+   categories: z.array(z.string()).optional(),
+})
+
+export const SearchPinsQuerySchema = z.object({
+   location: z
+      .object({
+         lat: z.number(),
+         lng: z.number(),
+         radius: z.number().positive(),
+      })
+      .optional(),
+   timeRange: z
+      .object({
+         start: z.string().datetime(),
+         end: z.string().datetime(),
+      })
+      .optional(),
+   categories: z.array(z.string()).optional(),
+   weather: z.array(z.string()).optional(),
+   limit: z.number().positive().max(100).default(50),
+   offset: z.number().nonnegative().default(0),
+})
+
+export const ReportPinRequestSchema = z.object({
+   reason: z.string().min(10).max(1000),
+})
+
+export const AudioMetadataSchema = z.object({
+   id: z.string(),
+   filename: z.string(),
+   size: z.number(),
+   format: AudioFormatSchema,
+   duration: z.number(),
+   url: z.string().optional(),
+   uploadedAt: z.string(),
+})
+
+export const AudioUploadResultSchema = z.object({
+   audioId: z.string(),
+   audioUrl: z.string(),
+   audioFilePath: z.string(),
+   metadata: AudioMetadataSchema,
+})
+
+export const UploadUrlDataSchema = z.object({
+   uploadUrl: z.string(),
+   filePath: z.string(),
+   expiresAt: z.string(),
+   maxFileSize: z.number(),
+})
+
+export const AnalysisJobResultSchema = z.object({
+   jobId: z.string(),
+   status: z.enum(["queued", "processing", "completed", "failed"]),
+   estimatedDuration: z.string().optional(),
+   statusUrl: z.string(),
+})
+
+export const AnalysisStatusSchema = z.object({
+   jobId: z.string(),
+   status: z.enum(["queued", "processing", "completed", "failed"]),
+   result: PythonAnalysisResultSchema.optional(),
+   error: z
+      .object({
+         message: z.string(),
+         code: z.string().optional(),
+      })
+      .optional(),
+   createdAt: z.string(),
+   startedAt: z.string().optional(),
+   completedAt: z.string().optional(),
+   retryCount: z.number(),
+})
+
+export type ApiWeatherData = z.infer<typeof ApiWeatherDataSchema>
+export type ApiError = z.infer<typeof ApiErrorSchema>
+export type ApiErrorResponse = z.infer<typeof ApiErrorResponseSchema>
+export type CreatePinRequest = z.infer<typeof CreatePinRequestSchema>
+export type UpdatePinRequest = z.infer<typeof UpdatePinRequestSchema>
+export type NearbyPinsQuery = z.infer<typeof NearbyPinsQuerySchema>
+export type SearchPinsQuery = z.infer<typeof SearchPinsQuerySchema>

--- a/packages/shared-types/src/api-contract.ts
+++ b/packages/shared-types/src/api-contract.ts
@@ -78,7 +78,6 @@ export const SoundPinApiSchema = z.object({
 })
 
 export const CreatePinRequestSchema = z.object({
-   userId: z.string().uuid().optional(),
    location: LocationCoordinatesSchema,
    audio: z
       .object({

--- a/packages/shared-types/src/api-contract.ts
+++ b/packages/shared-types/src/api-contract.ts
@@ -1,6 +1,10 @@
 import { z } from "zod"
 import { AudioFormatSchema, PythonAnalysisResultSchema } from "./audio.js"
-import { LocationCoordinatesSchema, MapBoundsSchema, TimeTagSchema } from "./location.js"
+import {
+   LocationCoordinatesSchema,
+   MapBoundsSchema,
+   TimeTagSchema,
+} from "./location.js"
 
 export const ApiWeatherDataSchema = z.object({
    temperature: z.number(),

--- a/packages/shared-types/src/api.ts
+++ b/packages/shared-types/src/api.ts
@@ -1,104 +1,41 @@
 import { z } from "zod"
 import {
-   LocationCoordinatesSchema,
-   MapBoundsSchema,
-   TimeTagSchema,
-} from "./location.js"
-import { WeatherDataSchema } from "./weather.js"
+   AiAnalysisSchema,
+   ApiErrorSchema,
+   CreatePinRequestSchema,
+   NearbyPinsQuerySchema,
+   SearchPinsQuerySchema,
+   SoundPinApiSchema,
+} from "./api-contract.js"
 
 /**
  * 音声ピン作成リクエストのスキーマ
+ *
+ * @deprecated API contract schemas live in `api-contract.ts`.
+ * Use `CreatePinRequestSchema` instead.
  */
-export const SoundPinCreateRequestSchema = z.object({
-   location: LocationCoordinatesSchema,
-   audio: z.object({
-      file: z.instanceof(File),
-      duration: z.number().positive(),
-      format: z.enum(["webm", "mp3", "wav"]),
-   }),
-   context: z
-      .object({
-         weather: WeatherDataSchema.optional(),
-         timeTag: TimeTagSchema,
-         deviceInfo: z.string().optional(),
-      })
-      .optional(),
-})
+export const SoundPinCreateRequestSchema = CreatePinRequestSchema
 
 /**
  * AI分析結果のスキーマ
+ *
+ * @deprecated Use `AiAnalysisSchema` from `api-contract.ts`.
  */
-export const AIAnalysisResultSchema = z.object({
-   transcription: z.string(),
-   categories: z.object({
-      emotion: z.string(),
-      topic: z.string(),
-      language: z.string(),
-      confidence: z.number().min(0).max(1),
-   }),
-   summary: z.string().optional(),
-})
+export const AIAnalysisResultSchema = AiAnalysisSchema
 
 /**
  * 音声ピンのスキーマ
+ *
+ * @deprecated Use `SoundPinApiSchema` from `api-contract.ts`.
  */
-export const SoundPinSchema = z.object({
-   id: z.string().uuid(),
-   latitude: z.number(),
-   longitude: z.number(),
-   primaryLabel: z.string(),
-   primaryConfidence: z.number().min(0).max(1),
-   recordedAt: z.string().datetime(),
-   audioFilePath: z.string().optional(),
-   classificationResults: z.array(z.unknown()).optional(),
-   weatherData: WeatherDataSchema.optional(),
-   timeTag: z.string().optional(),
-   createdAt: z.string().datetime(),
-   updatedAt: z.string().datetime(),
-})
-
-/**
- * 近隣ピン検索クエリのスキーマ
- */
-export const NearbyPinsQuerySchema = z.object({
-   bounds: MapBoundsSchema,
-   limit: z.number().positive().max(100).default(50),
-   categories: z.array(z.string()).optional(),
-})
-
-/**
- * ピン検索クエリのスキーマ
- */
-export const SearchPinsQuerySchema = z.object({
-   location: z
-      .object({
-         lat: z.number(),
-         lng: z.number(),
-         radius: z.number().positive(),
-      })
-      .optional(),
-   timeRange: z
-      .object({
-         start: z.string().datetime(),
-         end: z.string().datetime(),
-      })
-      .optional(),
-   categories: z.array(z.string()).optional(),
-   weather: z.array(z.string()).optional(),
-   limit: z.number().positive().max(100).default(50),
-   offset: z.number().nonnegative().default(0),
-})
+export const SoundPinSchema = SoundPinApiSchema
 
 /**
  * APIエラーレスポンスのスキーマ
+ *
+ * @deprecated Use `ApiErrorSchema` from `api-contract.ts`.
  */
-export const APIErrorSchema = z.object({
-   code: z.string(),
-   message: z.string(),
-   details: z.unknown().optional(),
-   timestamp: z.string().datetime(),
-   requestId: z.string(),
-})
+export const APIErrorSchema = ApiErrorSchema
 
 /**
  * API成功レスポンスの型定義
@@ -119,9 +56,11 @@ export interface APIErrorResponse {
 // Zodスキーマから推論した型
 export type SoundPinCreateRequest = z.infer<typeof SoundPinCreateRequestSchema>
 export type AIAnalysisResult = z.infer<typeof AIAnalysisResultSchema>
-export type SoundPin = z.infer<typeof SoundPinSchema>
-export type NearbyPinsQuery = z.infer<typeof NearbyPinsQuerySchema>
-export type SearchPinsQuery = z.infer<typeof SearchPinsQuerySchema>
+export type ApiSoundPin = z.infer<typeof SoundPinSchema>
+/**
+ * @deprecated Use `ApiSoundPin` or `SoundPinAPI` for API data.
+ */
+export type SoundPin = ApiSoundPin
 export type APIError = z.infer<typeof APIErrorSchema>
 
 /**

--- a/packages/shared-types/src/api.ts
+++ b/packages/shared-types/src/api.ts
@@ -1,10 +1,8 @@
-import { z } from "zod"
+import type { z } from "zod"
 import {
    AiAnalysisSchema,
    ApiErrorSchema,
    CreatePinRequestSchema,
-   NearbyPinsQuerySchema,
-   SearchPinsQuerySchema,
    SoundPinApiSchema,
 } from "./api-contract.js"
 

--- a/packages/shared-types/src/generated/hono-api.ts
+++ b/packages/shared-types/src/generated/hono-api.ts
@@ -863,6 +863,7 @@ export interface paths {
                      duration: number
                      /** @enum {string} */
                      format: "webm" | "mp3" | "wav"
+                     filePath?: string
                   }
                   audio_file_path?: string
                   metadata?: {
@@ -1671,6 +1672,7 @@ export interface paths {
                      duration: number
                      /** @enum {string} */
                      format: "webm" | "mp3" | "wav"
+                     filePath?: string
                   }
                   audio_file_path?: string
                   metadata?: {

--- a/packages/shared-types/src/generated/hono-api.ts
+++ b/packages/shared-types/src/generated/hono-api.ts
@@ -850,8 +850,6 @@ export interface paths {
          requestBody: {
             content: {
                "application/json": {
-                  /** Format: uuid */
-                  userId?: string
                   location: {
                      lat: number
                      lng: number
@@ -1659,8 +1657,6 @@ export interface paths {
          requestBody: {
             content: {
                "application/json": {
-                  /** Format: uuid */
-                  userId?: string
                   location: {
                      lat: number
                      lng: number

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -2,11 +2,13 @@
 
 // API関連の型とスキーマ
 export * from "./api.js"
+export * from "./api-contract.js"
 // 音声・分析関連
 export * from "./audio.js"
 // OpenAPI から自動生成された API 型
 export * from "./generated/index.js"
 export * from "./location.js"
+export * from "./openapi.js"
 
 // 音声ピン関連
 export * from "./soundPin.js"

--- a/packages/shared-types/src/openapi.ts
+++ b/packages/shared-types/src/openapi.ts
@@ -1,0 +1,58 @@
+import type { HonoApiPaths } from "./generated/index.js"
+
+type JsonContent<Response> = Response extends {
+   content: { "application/json": infer Json }
+}
+   ? Json
+   : never
+
+type JsonRequestBody<Operation> = Operation extends {
+   requestBody: { content: { "application/json": infer Body } }
+}
+   ? Body
+   : never
+
+type FormRequestBody<Operation> = Operation extends {
+   requestBody: { content: { "multipart/form-data": infer Body } }
+}
+   ? Body
+   : never
+
+export type HonoJsonResponse<
+   Path extends keyof HonoApiPaths,
+   Method extends keyof HonoApiPaths[Path],
+   Status extends PropertyKey = 200,
+> = HonoApiPaths[Path][Method] extends { responses: infer Responses }
+   ? Status extends keyof Responses
+      ? JsonContent<Responses[Status]>
+      : never
+   : never
+
+export type HonoJsonRequestBody<
+   Path extends keyof HonoApiPaths,
+   Method extends keyof HonoApiPaths[Path],
+> = JsonRequestBody<HonoApiPaths[Path][Method]>
+
+export type HonoFormRequestBody<
+   Path extends keyof HonoApiPaths,
+   Method extends keyof HonoApiPaths[Path],
+> = FormRequestBody<HonoApiPaths[Path][Method]>
+
+export type CreatePinResponse = HonoJsonResponse<"/api/pins", "post">
+export type UploadPinResponse = HonoJsonResponse<"/api/pins/upload", "post">
+export type NearbyPinsResponse = HonoJsonResponse<"/api/pins/nearby", "get">
+export type DeletePinResponse = HonoJsonResponse<"/api/pins/{id}", "delete">
+export type HonoSoundPin = CreatePinResponse["data"]
+export type NearbyPin = NearbyPinsResponse["data"][number]
+
+export type CreatePinRequestBody = HonoJsonRequestBody<"/api/pins", "post">
+export type UploadAudioResponse = HonoJsonResponse<"/api/audio/upload", "post">
+export type SubmitAnalysisJobResponse = HonoJsonResponse<
+   "/api/audio/{audioId}/analyze",
+   "post"
+>
+export type AnalysisStatusResponse = HonoJsonResponse<
+   "/api/audio/{audioId}/analysis/{jobId}/status",
+   "get"
+>
+export type AnalysisStatusData = AnalysisStatusResponse["data"]

--- a/packages/shared-types/src/soundPin.ts
+++ b/packages/shared-types/src/soundPin.ts
@@ -1,66 +1,20 @@
-import type { InferenceResult } from "./audio.js"
-import type { LocationCoordinates } from "./location.js"
-import type { WeatherData } from "./weather.js"
-
-/**
- * 音声ピンの基本データ型（API間共通）
- *
- * フロントエンド表示・バックエンドDB保存の両方で参照される標準形
- */
-export interface SoundPinData {
-   id: string
-   latitude: number
-   longitude: number
-   primaryLabel: string
-   primaryConfidence: number
-   recordedAt: string
-   audioFilePath?: string
-   classificationResults?: InferenceResult[]
-   weatherData?: WeatherData
-   timeTag?: string
-   createdAt: string
-   updatedAt: string
-}
+import type { z } from "zod"
+import {
+   AiAnalysisSchema,
+   SoundPinApiSchema,
+} from "./api-contract.js"
 
 /**
  * API音声情報
  */
-export interface SoundPinAudio {
-   url: string
-   duration: number
-   format: "webm" | "mp3" | "wav" | "mp4" | "m4a" | "flac" | "ogg"
-}
+export type SoundPinAudio = z.infer<typeof SoundPinApiSchema>["audio"]
 
 /**
  * AI分析結果
  */
-export interface AIAnalysis {
-   transcription: string
-   categories: {
-      emotion: string
-      topic: string
-      language: string
-      confidence: number
-   }
-   summary?: string
-}
+export type AIAnalysis = z.infer<typeof AiAnalysisSchema>
 
 /**
  * Sound pin APIレスポンス型（Backend API用ドメインモデル）
  */
-export interface SoundPinAPI {
-   id: string
-   userId?: string
-   location: LocationCoordinates
-   audio: SoundPinAudio
-   weather?: WeatherData
-   timeTag?: "朝" | "昼" | "夕" | "夜"
-   aiAnalysis?: AIAnalysis
-   status: "active" | "processing" | "deleted" | "reported"
-   title?: string
-   metadata?: {
-      deviceInfo?: string
-   }
-   createdAt: string
-   updatedAt: string
-}
+export type SoundPinAPI = z.infer<typeof SoundPinApiSchema>

--- a/packages/shared-types/src/soundPin.ts
+++ b/packages/shared-types/src/soundPin.ts
@@ -1,8 +1,5 @@
 import type { z } from "zod"
-import {
-   AiAnalysisSchema,
-   SoundPinApiSchema,
-} from "./api-contract.js"
+import type { AiAnalysisSchema, SoundPinApiSchema } from "./api-contract.js"
 
 /**
  * API音声情報


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Pull Request 概要

OpenAPI 型の利用経路を `@sonory/shared-types` に寄せつつ、Better Auth 前提の本番 DB スキーマによって壊れていた未認証ピン作成と音声推論フローを復旧します。

今回の PR では、現時点の方針どおり認証機能はいったん外し、`sound_pins.user_id` は `UUID NULL` として未認証投稿を許可する開発用スキーマへ戻します。Better Auth は既存ブランチをそのまま取り込まず、後続で設計し直す前提です。

## 変更内容

- `packages/shared-types/src/api-contract.ts` を追加し、API route の Zod schema を shared-types 側に集約
- `packages/shared-types/src/openapi.ts` を追加し、OpenAPI 生成型からレスポンス・リクエスト型を取り出す alias を定義
- Web のピン・音声分析 API 通信を OpenAPI 由来型へ移行
  - `useNearbyPins` のメイン地図取得経路も `NearbyPinsResponse` / `NearbyPin` に統一
  - weather の `null` 正規化を経路間で統一
- `SoundPinAPI` を手書き interface から `SoundPinApiSchema` の `z.infer` に変更
- Hono OpenAPI spec と `src/generated/hono-api.ts` を再生成
- Python 型 generator が `SoundPinAPI` / `AIAnalysis` / `SoundPinAudio` を contract schema から生成できるよう修正
- Supabase の auth 前提スキーマを未認証開発用へ戻す reset migration を追加
  - `sound_pins.user_id` を `UUID NULL` に戻す
  - auth 系テーブルと FK を削除
  - RLS / RPC を未認証投稿前提へ復元
- 音声推論の timeout を 120 秒へ延長し、アップロード済み `audioId` を使って分析ジョブを投入するよう修正
- 分析リトライ時に `analysis_results` の状態を queued へ戻すよう修正
- 未認証前提に合わせ、ピン作成リクエストから `userId` を削除し、サーバー側でも `sound_pins.user_id` を常に `null` 保存に固定
- 分析リトライ時に再キュー後も最初に返した `jobId` を追跡できるよう、queue message に `rootMessageId` を持たせて `analysis_results` の更新先を安定化

## 動作確認

1. `tsc -p packages/shared-types/tsconfig.json` — 成功
2. `tsc --noEmit -p apps/api/tsconfig.json` — 成功
3. `tsc --noEmit -p apps/web/tsconfig.json` — 成功
4. `tsc --noEmit -p packages/python-types/tsconfig.json` — 成功
5. Python 型生成 — 成功
6. Hono OpenAPI spec / generated 型の再出力 — 実施済み
7. `biome check src`（`apps/api`）— 成功
8. Web から以下の一連フローが成功することを確認済み
   - `POST /api/audio/upload` → 200
   - `POST /api/audio/:id/analyze` → 200
   - `POST /api/pins` → 200（`user_id: null`）
   - `GET /api/pins/nearby` → 200
9. 追加修正後の確認
   - `tsc -p packages/shared-types/tsconfig.json --noEmit` — 成功
   - `tsc --noEmit -p apps/api/tsconfig.json` — 成功
   - `tsc --noEmit -p apps/web/tsconfig.json` — 成功
   - `biome check`（変更対象の shared-types / api ファイル）— 成功

## 関連Issue

- なし

## レビューポイント

- `api-contract.ts` を API route Zod schema の主な source of truth として扱う方針で問題ないか
- 未認証ピン作成復旧のため、今回の migration で auth 系テーブル・FK を落とす判断が妥当か
- Better Auth はこの PR では扱わず、後続で現行コードに合わせて作り直す方針でよいか
- `useNearbyPins` は prefetch / dedupe / timeout の都合で独自 fetch を維持しつつ、レスポンス型だけ OpenAPI 由来に寄せています

<!-- for GitHub Copilot review rule -->
<!--
[must]       → must fix (修正必須)
[suggestion]→ suggestion (提案)
[nit]        → nit (軽微な指摘)
[question]   → question (確認したい点)
[info]       → info (参考情報)
-->
<!-- for GitHub Copilot review rule -->

<!-- I want to review in Japanese. -->